### PR TITLE
sym2inc: fix outputting garbage

### DIFF
--- a/src/tools/sym2inc/sym2inc.c
+++ b/src/tools/sym2inc/sym2inc.c
@@ -67,7 +67,7 @@ char * strupr ( char *pStr )
   char *pChr = pStr;
 
   while (*pChr != '\0') {
-    *pChr = _toupper(*pChr);
+    *pChr = toupper(*pChr);
     ++pChr;
   }
 


### PR DESCRIPTION
sym2inc was writing binary junk instead of hex addresses. turns out the strupr function that's called on them uses a function _toupper which doesn't exist anywhere in the source tree - at least i couldn't find it.
how the program linked successfully is a miracle to me, but whatever was linked in in place of toupper() didn't work as expected.

including ctype.h and using the official function makes the program work and thus the build succeeds - as sym2inc is called for compiling examples from the top-level makefile.