### PR TITLE
Fix bug in HuCC poke() function where the address can be corrupted

### DIFF
--- a/include/hucc/hucc-baselib.asm
+++ b/include/hucc/hucc-baselib.asm
@@ -127,10 +127,13 @@ _peekw.1	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __macro __xsafe poke( unsigned int addr<__ptr>, unsigned char with<acc> );
+; void __fastcall __macro __xsafe poke( unsigned int addr<__poke>, unsigned char with<acc> );
+;
+; N.B. Because the <acc> value can be a complex C calculation, it isn't safe
+; to use __ptr as the destination, which can be overwritten in C macros.
 
 _poke.2		.macro
-		sta	[__ptr]
+		sta	[__poke]
 		.endm
 
 
@@ -138,13 +141,16 @@ _poke.2		.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __macro __xsafe pokew( unsigned int addr<__ptr>, unsigned int with<acc> );
+; void __fastcall __macro __xsafe pokew( unsigned int addr<__poke>, unsigned int with<acc> );
+;
+; N.B. Because the <acc> value can be a complex C calculation, it isn't safe
+; to use __ptr as the destination, which can be overwritten in C macros.
 
 _pokew.2	.macro
-		sta	[__ptr]
+		sta	[__poke]
 		tya
 		ldy	#1
-		sta	[__ptr], y
+		sta	[__poke], y
 		.endm
 
 

--- a/include/hucc/hucc-baselib.h
+++ b/include/hucc/hucc-baselib.h
@@ -82,8 +82,8 @@ extern unsigned char __fastcall __xsafe __macro ac_exists( void );
 
 extern unsigned int __fastcall __xsafe __macro peek( unsigned int addr<__ptr> );
 extern unsigned int __fastcall __xsafe __macro peekw( unsigned int addr<__ptr> );
-extern void __fastcall __xsafe __macro poke( unsigned int addr<__ptr>, unsigned char with<acc> );
-extern void __fastcall __xsafe __macro pokew( unsigned int addr<__ptr>, unsigned int with<acc> );
+extern void __fastcall __xsafe __macro poke( unsigned int addr<__poke>, unsigned char with<acc> );
+extern void __fastcall __xsafe __macro pokew( unsigned int addr<__poke>, unsigned int with<acc> );
 
 extern unsigned int __fastcall __xsafe __farpeekw( void __far *addr<__fbank:__fptr> );
 

--- a/include/hucc/hucc.asm
+++ b/include/hucc/hucc.asm
@@ -125,6 +125,7 @@ __fbank		.ds	1
 __sp		.ds	1
 __stack		.ds	HUCC_STACK_SZ
 __ptr		.ds	2
+__poke		.ds	2
 
 		; Data pointer used by SDCC for indirect indexed memory access
 


### PR DESCRIPTION
during the calculation of the byte to be written.