### PR TITLE
Change HuCC to use the hardware stack for expressions.

### DIFF
--- a/examples/hucc/sgx/sgx_test.c
+++ b/examples/hucc/sgx/sgx_test.c
@@ -7,10 +7,10 @@
    easy to accomplish with a bit of inline asm!
    Note that HuC's scroll(), HuCC's scroll_split() and sgx_scroll_split()
    *all* override the current disp_on() or disp_off()! */
-void __fastcall __xsafe __macro pce_disp_on( void );
-void __fastcall __xsafe __macro pce_disp_off( void );
-void __fastcall __xsafe __macro sgx_disp_on( void );
-void __fastcall __xsafe __macro sgx_disp_off( void );
+void __fastcall __macro pce_disp_on( void );
+void __fastcall __macro pce_disp_off( void );
+void __fastcall __macro sgx_disp_on( void );
+void __fastcall __macro sgx_disp_off( void );
 #asm
 	.macro	_pce_disp_on
 	lda	#$C0

--- a/include/hucc/hucc-baselib.asm
+++ b/include/hucc/hucc-baselib.asm
@@ -19,7 +19,7 @@
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe dump_screen( void );
+; void __fastcall dump_screen( void );
 ;
 ; THIS IS AN ILLEGAL INSTRUCTION ONLY IMPLEMENTED BY THE TGEMU EMULATOR!
 
@@ -30,7 +30,7 @@ _dump_screen:	db	0x33
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe abort( void );
+; void __fastcall abort( void );
 ;
 ; THIS IS AN ILLEGAL INSTRUCTION ONLY IMPLEMENTED BY THE TGEMU EMULATOR!
 
@@ -41,7 +41,7 @@ _abort:		db	0xE2
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe exit( int value<acc> );
+; void __fastcall exit( int value<acc> );
 ;
 ; THIS IS AN ILLEGAL INSTRUCTION ONLY IMPLEMENTED BY THE TGEMU EMULATOR!
 
@@ -55,7 +55,7 @@ _exit.1:	tax				; Put the return code into X.
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned char __fastcall __xsafe __macro cd_execoverlay( unsigned char ovl_index<acc> );
+; unsigned char __fastcall __macro cd_execoverlay( unsigned char ovl_index<acc> );
 ;
 ; Execute program overlay from disc
 ;
@@ -71,8 +71,8 @@ _exit.1:	tax				; Put the return code into X.
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe __nop set_far_base( unsigned char data_bank<_bp_bank>, unsigned char *data_addr<_bp> );
-; void __fastcall __xsafe set_far_offset( unsigned int offset<_bp>, unsigned char data_bank<_bp_bank>, unsigned char *data_addr<acc> );
+; void __fastcall __nop set_far_base( unsigned char data_bank<_bp_bank>, unsigned char *data_addr<_bp> );
+; void __fastcall set_far_offset( unsigned int offset<_bp>, unsigned char data_bank<_bp_bank>, unsigned char *data_addr<acc> );
 
 _set_far_offset.3:
 		clc
@@ -101,7 +101,7 @@ _set_far_offset.3:
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned char __fastcall __xsafe __macro ac_exists( void );
+; unsigned char __fastcall __macro ac_exists( void );
 
 _ac_exists	.macro
 		cla
@@ -117,7 +117,7 @@ _ac_exists	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned char __fastcall __xsafe __macro _sgx_detect( void );
+; unsigned char __fastcall __macro _sgx_detect( void );
 
 _sgx_detect	.macro
 		lda	sgx_detected
@@ -129,7 +129,7 @@ _sgx_detect	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned int __fastcall __xsafe __macro peek( unsigned int addr<__ptr> );
+; unsigned int __fastcall __macro peek( unsigned int addr<__ptr> );
 
 _peek.1		.macro
 		lda	[__ptr]
@@ -141,7 +141,7 @@ _peek.1		.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned int __fastcall __xsafe __macro peekw( unsigned int addr<__ptr> );
+; unsigned int __fastcall __macro peekw( unsigned int addr<__ptr> );
 
 _peekw.1	.macro
 		lda	[__ptr]
@@ -157,7 +157,7 @@ _peekw.1	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __macro __xsafe poke( unsigned int addr<__poke>, unsigned char with<acc> );
+; void __fastcall __macro poke( unsigned int addr<__poke>, unsigned char with<acc> );
 ;
 ; N.B. Because the <acc> value can be a complex C calculation, it isn't safe
 ; to use __ptr as the destination, which can be overwritten in C macros.
@@ -171,7 +171,7 @@ _poke.2		.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __macro __xsafe pokew( unsigned int addr<__poke>, unsigned int with<acc> );
+; void __fastcall __macro pokew( unsigned int addr<__poke>, unsigned int with<acc> );
 ;
 ; N.B. Because the <acc> value can be a complex C calculation, it isn't safe
 ; to use __ptr as the destination, which can be overwritten in C macros.
@@ -188,7 +188,7 @@ _pokew.2	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned char __fastcall __xsafe __macro clock_hh( void );
+; unsigned char __fastcall __macro clock_hh( void );
 
 _clock_hh	.macro
 		lda	clock_hh
@@ -200,7 +200,7 @@ _clock_hh	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned char __fastcall __xsafe __macro clock_mm( void );
+; unsigned char __fastcall __macro clock_mm( void );
 
 _clock_mm	.macro
 		lda	clock_mm
@@ -212,7 +212,7 @@ _clock_mm	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned char __fastcall __xsafe __macro clock_ss( void );
+; unsigned char __fastcall __macro clock_ss( void );
 
 _clock_ss	.macro
 		lda	clock_ss
@@ -224,7 +224,7 @@ _clock_ss	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned char __fastcall __xsafe __macro clock_tt( void );
+; unsigned char __fastcall __macro clock_tt( void );
 
 _clock_tt	.macro
 		lda	clock_tt
@@ -236,7 +236,7 @@ _clock_tt	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe __macro clock_reset( void );
+; void __fastcall __macro clock_reset( void );
 
 _clock_reset	.macro
 		stz	clock_hh
@@ -250,8 +250,8 @@ _clock_reset	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe __macro vsync( void );
-; void __fastcall __xsafe __macro vsync( unsigned char count<acc> );
+; void __fastcall __macro vsync( void );
+; void __fastcall __macro vsync( unsigned char count<acc> );
 
 _vsync		.macro
 		jsr	wait_vsync
@@ -267,7 +267,7 @@ _vsync.1	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe __macro joy( unsigned char which<acc> );
+; void __fastcall __macro joy( unsigned char which<acc> );
 
 _joy.1		.macro
 	.if	SUPPORT_6BUTTON
@@ -288,7 +288,7 @@ _joy.1		.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe __macro joytrg( unsigned char which<acc> );
+; void __fastcall __macro joytrg( unsigned char which<acc> );
 
 _joytrg.1	.macro
 	.if	SUPPORT_6BUTTON
@@ -309,8 +309,8 @@ _joytrg.1	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe _nop set_color( unsigned int index<VCE_CTA>, unsigned int value<VCE_CTW> );
-; void __fastcall __xsafe set_color_rgb( unsigned int index<VCE_CTA>, unsigned char r<_al>, unsigned char g<_ah>, unsigned char b<acc> );
+; void __fastcall _nop set_color( unsigned int index<VCE_CTA>, unsigned int value<VCE_CTW> );
+; void __fastcall set_color_rgb( unsigned int index<VCE_CTA>, unsigned char r<_al>, unsigned char g<_ah>, unsigned char b<acc> );
 ;
 ; r:	red	RED:	bit 3-5
 ; g:	green	GREEN:	bit 6-8
@@ -346,7 +346,7 @@ _set_color_rgb.4:
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe _macro get_color( unsigned int index<VCE_CTA> );
+; void __fastcall _macro get_color( unsigned int index<VCE_CTA> );
 
 _get_color.1	.macro
 		lda.l	VCE_CTR
@@ -358,9 +358,9 @@ _get_color.1	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe srand( unsigned char seed<acc> );
-; unsigned int __fastcall __xsafe rand( void );
-; unsigned char __fastcall __xsafe rand8( void );
+; void __fastcall srand( unsigned char seed<acc> );
+; unsigned int __fastcall rand( void );
+; unsigned char __fastcall rand8( void );
 
 	.ifndef	HUCC_NO_DEFAULT_RANDOM
 		.alias	_srand.1		= init_random
@@ -375,7 +375,7 @@ _rand:		jsr	get_random		; Random in A, preserve Y.
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned char __fastcall __xsafe random8( unsigned char limit<acc> );
+; unsigned char __fastcall random8( unsigned char limit<acc> );
 ;
 ; IN :	A = range (0..255)
 ; OUT : A = random number interval 0 <= x < A
@@ -385,7 +385,7 @@ _rand:		jsr	get_random		; Random in A, preserve Y.
 _random8.1:	tay				; Preserve the limit.
 		jsr	get_random		; Random in A, preserve Y.
 
-		jsr	__muluchar		; This is __xsafe!
+		jsr	__muluchar
 		tya				; Do a 8.0 x 0.8 fixed point
 		cly				; fractional multiply.
 		rts
@@ -396,7 +396,7 @@ _random8.1:	tay				; Preserve the limit.
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned char __fastcall __xsafe random( unsigned char limit<acc> );
+; unsigned char __fastcall random( unsigned char limit<acc> );
 ;
 ; IN :	A = range (0..128), 129..255 is treated as 128
 ; OUT : A = random number interval 0 <= x < A
@@ -413,7 +413,7 @@ _random.1:	tay				; Preserve the limit.
 		cly				; the limit is >= 128.
 		rts
 
-!:		jsr	__muluchar		; This is __xsafe!
+!:		jsr	__muluchar
 		tya				; If the limit is < 128 then
 		cly				; do a 8.0 x 0.8 fixed point
 		rts				; fractional multiply.
@@ -455,11 +455,11 @@ _random.1:	tay				; Preserve the limit.
 ;
 ; N.B. Declared in hucc-gfx.h, but defined here because they're macros!
 ;
-; void __fastcall __xsafe _macro set_xres( unsigned int x_pixels<_ax> );
-; void __fastcall __xsafe _macro sgx_set_xres( unsigned int x_pixels<_ax> );
+; void __fastcall _macro set_xres( unsigned int x_pixels<_ax> );
+; void __fastcall _macro sgx_set_xres( unsigned int x_pixels<_ax> );
 ;
-; void __fastcall __xsafe set_xres( unsigned int x_pixels<_ax>, unsigned char blur_flag<_bl> );
-; void __fastcall __xsafe sgx_set_xres( unsigned int x_pixels<_ax>, unsigned char blur_flag<_bl> );
+; void __fastcall set_xres( unsigned int x_pixels<_ax>, unsigned char blur_flag<_bl> );
+; void __fastcall sgx_set_xres( unsigned int x_pixels<_ax>, unsigned char blur_flag<_bl> );
 
 _set_xres.1	.macro
 		lda	#XRES_SOFT
@@ -482,8 +482,8 @@ _set_xres.1	.macro
 ;
 ; N.B. Declared in hucc-gfx.h, but defined here because they're macros!
 ;
-; unsigned int __fastcall __xsafe __macro vram_addr( unsigned char bat_x<_al>, unsigned char bat_y<_ah> );
-; unsigned int __fastcall __xsafe __macro sgx_vram_addr( unsigned char bat_x<_al>, unsigned char bat_y<_ah> );
+; unsigned int __fastcall __macro vram_addr( unsigned char bat_x<_al>, unsigned char bat_y<_ah> );
+; unsigned int __fastcall __macro sgx_vram_addr( unsigned char bat_x<_al>, unsigned char bat_y<_ah> );
 
 		.macro	_vram_addr.2
 		cla
@@ -524,11 +524,11 @@ _set_xres.1	.macro
 ;
 ; N.B. Declared in hucc-gfx.h, but defined here because they're macros!
 ;
-; unsigned int __fastcall __xsafe __macro get_vram( unsigned int address<_di> );
-; void __fastcall __xsafe __macro put_vram( unsigned int address<_di>, unsigned int data<acc> );
+; unsigned int __fastcall __macro get_vram( unsigned int address<_di> );
+; void __fastcall __macro put_vram( unsigned int address<_di>, unsigned int data<acc> );
 ;
-; unsigned int __fastcall __xsafe __macro sgx_get_vram( unsigned int address<_di> );
-; void __fastcall __xsafe __macro sgx_put_vram( unsigned int address<_di>, unsigned int data<acc> );
+; unsigned int __fastcall __macro sgx_get_vram( unsigned int address<_di> );
+; void __fastcall __macro sgx_put_vram( unsigned int address<_di>, unsigned int data<acc> );
 
 		.macro	_get_vram.1
 		phx
@@ -575,10 +575,10 @@ _set_xres.1	.macro
 ;
 ; N.B. Declared in hucc-gfx.h, but defined here because they're macros!
 ;
-; void __fastcall __xsafe __macro set_bgpal( unsigned char palette<_al>, unsigned char __far *data<_bp_bank:_bp> );
-; void __fastcall __xsafe __macro set_bgpal( unsigned char palette<_al>, unsigned char __far *data<_bp_bank:_bp>, unsigned int num_palettes<_ah> );
-; void __fastcall __xsafe __macro set_sprpal( unsigned char palette<_al>, unsigned char __far *data<_bp_bank:_bp> );
-; void __fastcall __xsafe __macro set_sprpal( unsigned char palette<_al>, unsigned char __far *data<_bp_bank:_bp>, unsigned int num_palettes<_ah> );
+; void __fastcall __macro set_bgpal( unsigned char palette<_al>, unsigned char __far *data<_bp_bank:_bp> );
+; void __fastcall __macro set_bgpal( unsigned char palette<_al>, unsigned char __far *data<_bp_bank:_bp>, unsigned int num_palettes<_ah> );
+; void __fastcall __macro set_sprpal( unsigned char palette<_al>, unsigned char __far *data<_bp_bank:_bp> );
+; void __fastcall __macro set_sprpal( unsigned char palette<_al>, unsigned char __far *data<_bp_bank:_bp>, unsigned int num_palettes<_ah> );
 
 _set_bgpal.2	.macro
 		lda	#1

--- a/include/hucc/hucc-baselib.h
+++ b/include/hucc/hucc-baselib.h
@@ -85,59 +85,59 @@ extern unsigned char dh;
 
 #asmdef	HUCC_USES_BASELIB 1
 
-extern void __fastcall __xsafe __nop set_far_base( unsigned char data_bank<_bp_bank>, unsigned char *data_addr<_bp> );
-extern void __fastcall __xsafe set_far_offset( unsigned int offset<_bp>, unsigned char data_bank<_bp_bank>, unsigned char *data_addr<acc> );
+extern void __fastcall __nop set_far_base( unsigned char data_bank<_bp_bank>, unsigned char *data_addr<_bp> );
+extern void __fastcall set_far_offset( unsigned int offset<_bp>, unsigned char data_bank<_bp_bank>, unsigned char *data_addr<acc> );
 
-extern unsigned char __fastcall __xsafe __macro sgx_detect( void );
-extern unsigned char __fastcall __xsafe __macro ac_exists( void );
+extern unsigned char __fastcall __macro sgx_detect( void );
+extern unsigned char __fastcall __macro ac_exists( void );
 
-extern void __fastcall __xsafe __nop vpc_set_ctl( unsigned int bits<VPC_CR> );
-extern void __fastcall __xsafe __nop vpc_set_win1( unsigned int width<VPC_WINDOW1> );
-extern void __fastcall __xsafe __nop vpc_set_win2( unsigned int width<VPC_WINDOW2> );
+extern void __fastcall __nop vpc_set_ctl( unsigned int bits<VPC_CR> );
+extern void __fastcall __nop vpc_set_win1( unsigned int width<VPC_WINDOW1> );
+extern void __fastcall __nop vpc_set_win2( unsigned int width<VPC_WINDOW2> );
 
-extern unsigned int __fastcall __xsafe __macro peek( unsigned int addr<__ptr> );
-extern unsigned int __fastcall __xsafe __macro peekw( unsigned int addr<__ptr> );
-extern void __fastcall __xsafe __macro poke( unsigned int addr<__poke>, unsigned char with<acc> );
-extern void __fastcall __xsafe __macro pokew( unsigned int addr<__poke>, unsigned int with<acc> );
+extern unsigned int __fastcall __macro peek( unsigned int addr<__ptr> );
+extern unsigned int __fastcall __macro peekw( unsigned int addr<__ptr> );
+extern void __fastcall __macro poke( unsigned int addr<__poke>, unsigned char with<acc> );
+extern void __fastcall __macro pokew( unsigned int addr<__poke>, unsigned int with<acc> );
 
-extern unsigned int __fastcall __xsafe __farpeekw( void __far *addr<__fbank:__fptr> );
+extern unsigned int __fastcall __farpeekw( void __far *addr<__fbank:__fptr> );
 
-extern void __fastcall __xsafe __macro vsync( void );
-extern void __fastcall __xsafe __macro vsync( unsigned char count<acc> );
+extern void __fastcall __macro vsync( void );
+extern void __fastcall __macro vsync( unsigned char count<acc> );
 
-extern unsigned int __fastcall __xsafe __macro joy( unsigned char which<acc> );
-extern unsigned int __fastcall __xsafe __macro joytrg( unsigned char which<acc> );
+extern unsigned int __fastcall __macro joy( unsigned char which<acc> );
+extern unsigned int __fastcall __macro joytrg( unsigned char which<acc> );
 
-extern void __fastcall __xsafe __nop set_color( unsigned int index<VCE_CTA>, unsigned int value<VCE_CTW> );
-extern void __fastcall __xsafe set_color_rgb( unsigned int index<VCE_CTA>, unsigned char r<_al>, unsigned char g<_ah>, unsigned char b<acc> );
-extern unsigned int __fastcall __xsafe __macro get_color( unsigned int index<VCE_CTA> );
+extern void __fastcall __nop set_color( unsigned int index<VCE_CTA>, unsigned int value<VCE_CTW> );
+extern void __fastcall set_color_rgb( unsigned int index<VCE_CTA>, unsigned char r<_al>, unsigned char g<_ah>, unsigned char b<acc> );
+extern unsigned int __fastcall __macro get_color( unsigned int index<VCE_CTA> );
 
-extern unsigned char __fastcall __xsafe __macro clock_hh( void );
-extern unsigned char __fastcall __xsafe __macro clock_mm( void );
-extern unsigned char __fastcall __xsafe __macro clock_ss( void );
-extern unsigned char __fastcall __xsafe __macro clock_tt( void );
-extern void __fastcall __xsafe __macro clock_reset( void );
+extern unsigned char __fastcall __macro clock_hh( void );
+extern unsigned char __fastcall __macro clock_mm( void );
+extern unsigned char __fastcall __macro clock_ss( void );
+extern unsigned char __fastcall __macro clock_tt( void );
+extern void __fastcall __macro clock_reset( void );
 
-extern unsigned char __fastcall __xsafe __macro cd_execoverlay( unsigned char ovl_index<acc> );
+extern unsigned char __fastcall __macro cd_execoverlay( unsigned char ovl_index<acc> );
 
-extern int __fastcall __xsafe abs( int value<acc> );
+extern int __fastcall abs( int value<acc> );
 
-extern void __fastcall __xsafe srand( unsigned char seed<acc> );
-extern unsigned int __fastcall __xsafe rand( void );
-extern unsigned char __fastcall __xsafe rand8( void );
+extern void __fastcall srand( unsigned char seed<acc> );
+extern unsigned int __fastcall rand( void );
+extern unsigned char __fastcall rand8( void );
 
 // Note: "limit" is 0..255.
-extern unsigned char __fastcall __xsafe random8( unsigned char limit<acc> );
+extern unsigned char __fastcall random8( unsigned char limit<acc> );
 
 // Note: "limit" is 0..128, 129..255 is treated as 128!
-extern unsigned char __fastcall __xsafe random( unsigned char limit<acc> );
+extern unsigned char __fastcall random( unsigned char limit<acc> );
 
 // Functions that are only implemented in the TGEMU emulator for unit-testing
 // the compiler and which should never be used in normal HuCC projects ...
 
-extern void __fastcall __xsafe dump_screen( void );
-extern void __fastcall __xsafe abort( void );
-extern void __fastcall __xsafe exit( int value<acc> );
+extern void __fastcall dump_screen( void );
+extern void __fastcall abort( void );
+extern void __fastcall exit( int value<acc> );
 
 extern unsigned char __fastcall __builtin_ffs( unsigned int value<__temp> );
 

--- a/include/hucc/hucc-gfx.asm
+++ b/include/hucc/hucc-gfx.asm
@@ -32,8 +32,8 @@ _font_base	.ds	2
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe disp_on( void );
-; void __fastcall __xsafe disp_off( void );
+; void __fastcall disp_on( void );
+; void __fastcall disp_off( void );
 
 		.alias	_disp_on		= set_dspon
 		.alias	_disp_off		= set_dspoff
@@ -43,7 +43,7 @@ _font_base	.ds	2
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe set256x224( void );
+; void __fastcall set256x224( void );
 
 _set_256x224	.proc
 
@@ -142,8 +142,8 @@ _set_256x224	.proc
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe set_screen_size( unsigned char value<_al> );
-; void __fastcall __xsafe sgx_set_screen_size( unsigned char value<_al> );
+; void __fastcall set_screen_size( unsigned char value<_al> );
+; void __fastcall sgx_set_screen_size( unsigned char value<_al> );
 ;
 ; screen_size_sgx
 ; screen_size_vdc
@@ -154,10 +154,10 @@ _set_256x224	.proc
 ;
 ; (VDC_MWR_32x32  >> 4) or in HuC, SCR_SIZE_32x32
 ; (VDC_MWR_32x64  >> 4) or in HuC, SCR_SIZE_32x64
-; (VDC_MWR_64x32  >> 4) or in HuC, SCR_SIZE_64x32 
-; (VDC_MWR_64x64  >> 4) or in HuC, SCR_SIZE_64x64 
-; (VDC_MWR_128x32 >> 4) or in HuC, SCR_SIZE_128x32 
-; (VDC_MWR_128x64 >> 4) or in HuC, SCR_SIZE_128x64 
+; (VDC_MWR_64x32  >> 4) or in HuC, SCR_SIZE_64x32
+; (VDC_MWR_64x64  >> 4) or in HuC, SCR_SIZE_64x64
+; (VDC_MWR_128x32 >> 4) or in HuC, SCR_SIZE_128x32
+; (VDC_MWR_128x64 >> 4) or in HuC, SCR_SIZE_128x64
 
 huc_screen_size	.procgroup
 
@@ -300,11 +300,11 @@ sgx_tile_base	ds	2	; Where the TILE data is in VRAM / 16.
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe _macro set_xres( unsigned int x_pixels<_ax> );
-; void __fastcall __xsafe _macro sgx_set_xres( unsigned int x_pixels<_ax> );
+; void __fastcall _macro set_xres( unsigned int x_pixels<_ax> );
+; void __fastcall _macro sgx_set_xres( unsigned int x_pixels<_ax> );
 ;
-; void __fastcall __xsafe set_xres( unsigned int x_pixels<_ax>, unsigned char blur_flag<_bl> );
-; void __fastcall __xsafe sgx_set_xres( unsigned int x_pixels<_ax>, unsigned char blur_flag<_bl> );
+; void __fastcall set_xres( unsigned int x_pixels<_ax>, unsigned char blur_flag<_bl> );
+; void __fastcall sgx_set_xres( unsigned int x_pixels<_ax>, unsigned char blur_flag<_bl> );
 ;
 ; blur_flag = XRES_SOFT (default if not specified), XRES_SHARP or XRES_KEEP
 
@@ -391,7 +391,7 @@ _set_xres.2	.proc
 		sta	VDC_DL, x
 		lda	<.hds
 		sta	VDC_DH, x
-	
+
 		lda	#VDC_HDR		; Set the VDC's HDR register.
 		sta	<vdc_reg, x
 		sta	VDC_AR, x
@@ -399,7 +399,7 @@ _set_xres.2	.proc
 		sta	VDC_DL, x
 		lda	<.hde
 		sta	VDC_DH, x
-	
+
 		plp				; Restore interrupts.
 
 !exit:		plx				; Restore X (aka __sp).
@@ -441,7 +441,7 @@ set_tile_base:	sty	<__temp			; Set TILE base = (VRAM / 16).
 		sta.l	vdc_tile_base, x
 		lda	<__temp
 		sta.h	vdc_tile_base, x
-		rts 
+		rts
 
 		.alias	_set_tile_address.1	= set_tiles_vdc
 		.alias	_sgx_set_tile_address.1	= set_tiles_sgx
@@ -454,13 +454,13 @@ set_tile_base:	sty	<__temp			; Set TILE base = (VRAM / 16).
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe set_tile_data( unsigned char *tile_ex<_di> );
+; void __fastcall set_tile_data( unsigned char *tile_ex<_di> );
 ;
-; void __fastcall __xsafe __nop set_tile_data( unsigned char far *map<vdc_tile_bank:vdc_tile_addr>, unsigned char nb_tile<vdc_num_tiles>, unsigned char far *ptable<vdc_attr_bank:vdc_attr_addr>, unsigned char type<vdc_tile_type> );
-; void __fastcall __xsafe __nop sgx_set_tile_data( unsigned char far *map<vdc_tile_bank:vdc_tile_addr>, unsigned char nb_tile<vdc_num_tiles>, unsigned char far *ptable<vdc_attr_bank:vdc_attr_addr>, unsigned char type<vdc_tile_type> );
+; void __fastcall __nop set_tile_data( unsigned char far *map<vdc_tile_bank:vdc_tile_addr>, unsigned char nb_tile<vdc_num_tiles>, unsigned char far *ptable<vdc_attr_bank:vdc_attr_addr>, unsigned char type<vdc_tile_type> );
+; void __fastcall __nop sgx_set_tile_data( unsigned char far *map<vdc_tile_bank:vdc_tile_addr>, unsigned char nb_tile<vdc_num_tiles>, unsigned char far *ptable<vdc_attr_bank:vdc_attr_addr>, unsigned char type<vdc_tile_type> );
 ;
-; void __fastcall __xsafe __nop set_far_tile_data( unsigned char tile_bank<vdc_tile_bank>, unsigned char *tile_addr<vdc_tile_addr>, unsigned char num_tiles<vdc_num_tiles>, unsigned char palette_table_bank<vdc_attr_bank>, unsigned char *palette_table_addr<vdc_attr_addr>, unsigned char tile_type<vdc_tile_type> );
-; void __fastcall __xsafe __nop sgx_set_far_tile_data( unsigned char tile_bank<vdc_tile_bank>, unsigned char *tile_addr<vdc_tile_addr>, unsigned char num_tiles<vdc_num_tiles>, unsigned char palette_table_bank<vdc_attr_bank>, unsigned char *palette_table_addr<vdc_attr_addr>, unsigned char tile_type<vdc_tile_type> );
+; void __fastcall __nop set_far_tile_data( unsigned char tile_bank<vdc_tile_bank>, unsigned char *tile_addr<vdc_tile_addr>, unsigned char num_tiles<vdc_num_tiles>, unsigned char palette_table_bank<vdc_attr_bank>, unsigned char *palette_table_addr<vdc_attr_addr>, unsigned char tile_type<vdc_tile_type> );
+; void __fastcall __nop sgx_set_far_tile_data( unsigned char tile_bank<vdc_tile_bank>, unsigned char *tile_addr<vdc_tile_addr>, unsigned char num_tiles<vdc_num_tiles>, unsigned char palette_table_bank<vdc_attr_bank>, unsigned char *palette_table_addr<vdc_attr_addr>, unsigned char tile_type<vdc_tile_type> );
 ;
 ; tile,	tile base index
 ; nb_tile, number of tile
@@ -512,8 +512,8 @@ load_vram_group	.procgroup			; These routines share code!
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe load_tile( unsigned int vram<_di> );
-; void __fastcall __xsafe sgx_load_tile( unsigned int vram<_di> );
+; void __fastcall load_tile( unsigned int vram<_di> );
+; void __fastcall sgx_load_tile( unsigned int vram<_di> );
 
 	.if	SUPPORT_SGX
 		.proc	_sgx_load_tile.1
@@ -561,7 +561,7 @@ load_vram_group	.procgroup			; These routines share code!
 		ror.l	<_ax
 
 !:		sta.h	<_ax
-		bra	huc_load_vram		; This is __xsafe!
+		bra	huc_load_vram
 
 		.ref	_load_vram.3
 		.endp
@@ -571,11 +571,11 @@ load_vram_group	.procgroup			; These routines share code!
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe load_vram( unsigned int vram<_di>, unsigned char __far *data<_bp_bank:_bp>, unsigned int num_words<_ax> );
-; void __fastcall __xsafe sgx_load_vram( unsigned int vram<_di>, unsigned char __far *data<_bp_bank:_bp>, unsigned int num_words<_ax> );
+; void __fastcall load_vram( unsigned int vram<_di>, unsigned char __far *data<_bp_bank:_bp>, unsigned int num_words<_ax> );
+; void __fastcall sgx_load_vram( unsigned int vram<_di>, unsigned char __far *data<_bp_bank:_bp>, unsigned int num_words<_ax> );
 ;
-; void __fastcall __xsafe far_load_vram( unsigned int vram<_di>, unsigned int num_words<_ax> );
-; void __fastcall __xsafe sgx_far_load_vram( unsigned int vram<_di>, unsigned int num_words<_ax> );
+; void __fastcall far_load_vram( unsigned int vram<_di>, unsigned int num_words<_ax> );
+; void __fastcall sgx_far_load_vram( unsigned int vram<_di>, unsigned int num_words<_ax> );
 ;
 ; load_vram_sgx -  copy a block of memory to VRAM
 ; load_vram_vdc -  copy a block of memory to VRAM
@@ -707,11 +707,11 @@ huc_load_vram:	tma3
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe load_bat( unsigned int vram<_di>, unsigned char __far *data<_bp_bank:_bp>, unsigned char tiles_w<_al>, unsigned char tiles_h<_ah> );
-; void __fastcall __xsafe sgx_load_bat( unsigned int vram<_di>, unsigned char __far *data<_bp_bank:_bp>, unsigned char tiles_w<_al>, unsigned char tiles_h<_ah> );
+; void __fastcall load_bat( unsigned int vram<_di>, unsigned char __far *data<_bp_bank:_bp>, unsigned char tiles_w<_al>, unsigned char tiles_h<_ah> );
+; void __fastcall sgx_load_bat( unsigned int vram<_di>, unsigned char __far *data<_bp_bank:_bp>, unsigned char tiles_w<_al>, unsigned char tiles_h<_ah> );
 ;
-; void __fastcall __xsafe far_load_bat( unsigned int vram<_di>, unsigned char tiles_w<_al>, unsigned char tiles_h<_ah> );
-; void __fastcall __xsafe sgx_far_load_bat( unsigned int vram<_di>, unsigned char tiles_w<_al>, unsigned char tiles_h<_ah> );
+; void __fastcall far_load_bat( unsigned int vram<_di>, unsigned char tiles_w<_al>, unsigned char tiles_h<_ah> );
+; void __fastcall sgx_far_load_bat( unsigned int vram<_di>, unsigned char tiles_w<_al>, unsigned char tiles_h<_ah> );
 ;
 ; load_bat_sgx - transfer a BAT to VRAM
 ; load_bat_vdc - transfer a BAT to VRAM
@@ -801,9 +801,9 @@ load_bat_group	.procgroup			; These routines share code!
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe load_palette( unsigned char palette<_al>, unsigned char __far *data<_bp_bank:_bp>, unsigned char num_palettes<_ah> );
+; void __fastcall load_palette( unsigned char palette<_al>, unsigned char __far *data<_bp_bank:_bp>, unsigned char num_palettes<_ah> );
 ;
-; void __fastcall __xsafe far_load_palette( unsigned char palette<_al>, unsigned char num_palettes<_ah> );
+; void __fastcall far_load_palette( unsigned char palette<_al>, unsigned char num_palettes<_ah> );
 
 		.proc	_load_palette.3
 		.alias	_far_load_palette.2	= _load_palette.3
@@ -867,7 +867,7 @@ _gfx_load_vram:
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe load_background( unsigned char __far *tiles<_bp_bank:_bp>, unsigned char __far *palettes<__fbank:__fptr>, unsigned char __far *bat<_cl:_bx>, unsigned char w<_dl>, unsigned char w<_dh> );
+; void __fastcall load_background( unsigned char __far *tiles<_bp_bank:_bp>, unsigned char __far *palettes<__fbank:__fptr>, unsigned char __far *bat<_cl:_bx>, unsigned char w<_dl>, unsigned char w<_dh> );
 
 		.proc	_load_background.5
 
@@ -877,7 +877,7 @@ _gfx_load_vram:
 		stz.l	<_ax
 		lda.h	#$4000
 		sta.h	<_ax
-		call	_load_vram.3		; This is __xsafe!
+		call	_load_vram.3
 
 		lda.l	<__fptr
 		sta.l	<_bp
@@ -888,9 +888,9 @@ _gfx_load_vram:
 		stz	<_al
 		lda	#16
 		sta	<_ah
-		call	_load_palette.3		; This is __xsafe!
+		call	_load_palette.3
 
-		jsr	wait_vsync		; This is __xsafe!
+		jsr	wait_vsync
 
 		stz.l	<_di
 		stz.h	<_di
@@ -904,7 +904,7 @@ _gfx_load_vram:
 		sta	<_al
 		lda	<_dh
 		sta	<_ah
-		jmp	_load_bat.4		; This is __xsafe!
+		jmp	_load_bat.4
 
 		.endp
 
@@ -919,7 +919,7 @@ _gfx_load_vram:
 ; ***************************************************************************
 
 ; **************
-; void __fastcall __xsafe set_font_addr( unsigned int vram<acc> );
+; void __fastcall set_font_addr( unsigned int vram<acc> );
 
 _set_font_addr:
 		sty	<__temp
@@ -947,7 +947,7 @@ _set_font_addr:
 
 
 ; **************
-; void __fastcall __xsafe set_font_pal( unsigned char palette<acc> );
+; void __fastcall set_font_pal( unsigned char palette<acc> );
 
 _set_font_pal:
 		asl	a
@@ -966,10 +966,10 @@ _set_font_pal:
 
 
 ; **************
-; void __fastcall __xsafe load_font( char far *font<_bp_bank:_bp>, unsigned char count<_al> );
-; void __fastcall __xsafe load_font( char far *font<_bp_bank:_bp>, unsigned char count<_al>, unsigned int vram<acc> );
+; void __fastcall load_font( char far *font<_bp_bank:_bp>, unsigned char count<_al> );
+; void __fastcall load_font( char far *font<_bp_bank:_bp>, unsigned char count<_al>, unsigned int vram<acc> );
 ;
-; void __fastcall __xsafe far_load_font( unsigned char count<_al>, unsigned int vram<acc> );
+; void __fastcall far_load_font( unsigned char count<_al>, unsigned int vram<acc> );
 
 _load_font.2:	ldy	vdc_bat_limit		; BAT limit mask hi-byte.
 		iny
@@ -991,7 +991,7 @@ _load_font.3:	sta.l	<_di			; Load the font directly
 		asl	a
 		rol	<__ah
 		sta	<__al
-		jmp	_load_vram.3		; This is __xsafe!
+		jmp	_load_vram.3
 
 		.alias	_far_load_font.2	= _load_font.3
 
@@ -1019,7 +1019,7 @@ _cls.1:		sta.l	<_ax			; VRAM word to write.
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe load_default_font( void );
+; void __fastcall load_default_font( void );
 ;
 ; huc_font_sgx - transfer a 8x8 monochrome font into VRAM
 ; huc_font_vdc - transfer a 8x8 monochrome font into VRAM
@@ -1187,7 +1187,7 @@ vdc_tty_out	.procgroup			; These routines share code!
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe put_char( unsigned char digit<_bl>, unsigned char bat_x<_dil>, unsigned char bat_y<_dih> );
+; void __fastcall put_char( unsigned char digit<_bl>, unsigned char bat_x<_dil>, unsigned char bat_y<_dih> );
 
 	.if	SUPPORT_SGX
 put_char_sgx	.proc
@@ -1225,7 +1225,7 @@ put_char_vdc	.proc
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe put_digit( unsigned char digit<_bl>, unsigned char bat_x<_dil>, unsigned char bat_y<_dih> );
+; void __fastcall put_digit( unsigned char digit<_bl>, unsigned char bat_x<_dil>, unsigned char bat_y<_dih> );
 
 	.if	SUPPORT_SGX
 put_digit_sgx	.proc
@@ -1268,7 +1268,7 @@ put_digit_vdc	.proc
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe put_hex( unsigned int number<_bx>, unsigned char length<_cl>, unsigned char bat_x<_dil>, unsigned char bat_y<_dih> );
+; void __fastcall put_hex( unsigned int number<_bx>, unsigned char length<_cl>, unsigned char bat_x<_dil>, unsigned char bat_y<_dih> );
 
 	.if	SUPPORT_SGX
 put_hex_sgx	.proc
@@ -1348,7 +1348,7 @@ put_hex_vdc	.proc
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe put_number( unsigned int number<_bx>, unsigned char length<_cl>, unsigned char bat_x<_dil>, unsigned char bat_y<_dih> );
+; void __fastcall put_number( unsigned int number<_bx>, unsigned char length<_cl>, unsigned char bat_x<_dil>, unsigned char bat_y<_dih> );
 
 	.if	SUPPORT_SGX
 put_number_sgx	.proc
@@ -1437,7 +1437,7 @@ put_number_vdc	.proc
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe put_raw( unsigned int data<_bx>, unsigned char bat_x<_dil>, unsigned char bat_y<_dih> );
+; void __fastcall put_raw( unsigned int data<_bx>, unsigned char bat_x<_dil>, unsigned char bat_y<_dih> );
 
 	.if	SUPPORT_SGX
 put_raw_sgx	.proc
@@ -1477,7 +1477,7 @@ put_raw_vdc	.proc
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe put_string( unsigned char *string<_bp>, unsigned char bat_x<_dil>, unsigned char bat_y<_dih> );
+; void __fastcall put_string( unsigned char *string<_bp>, unsigned char bat_x<_dil>, unsigned char bat_y<_dih> );
 ;
 ; N.B. This is not a .proc right now because it is called from procedures
 ; that contain embedded strings, and the string aren't banked in before

--- a/include/hucc/hucc-gfx.h
+++ b/include/hucc/hucc-gfx.h
@@ -55,90 +55,90 @@
 
 #asmdef	HUCC_USES_GFX 1
 
-extern void __fastcall __xsafe set_256x224( void );
-//extern void __fastcall __xsafe set_352x224( void );
-//extern void __fastcall __xsafe set_496x224( void );
+extern void __fastcall set_256x224( void );
+//extern void __fastcall set_352x224( void );
+//extern void __fastcall set_496x224( void );
 
-extern void __fastcall __xsafe set_screen_size( unsigned char value<_al> );
-extern void __fastcall __xsafe sgx_set_screen_size( unsigned char value<_al> );
+extern void __fastcall set_screen_size( unsigned char value<_al> );
+extern void __fastcall sgx_set_screen_size( unsigned char value<_al> );
 
-extern void __fastcall __xsafe __macro set_xres( unsigned int x_pixels<_ax> );
-extern void __fastcall __xsafe __macro sgx_set_xres( unsigned int x_pixels<_ax> );
+extern void __fastcall __macro set_xres( unsigned int x_pixels<_ax> );
+extern void __fastcall __macro sgx_set_xres( unsigned int x_pixels<_ax> );
 
-extern void __fastcall __xsafe set_xres( unsigned int x_pixels<_ax>, unsigned char blur_flag<_bl> );
-extern void __fastcall __xsafe sgx_set_xres( unsigned int x_pixels<_ax>, unsigned char blur_flag<_bl> );
+extern void __fastcall set_xres( unsigned int x_pixels<_ax>, unsigned char blur_flag<_bl> );
+extern void __fastcall sgx_set_xres( unsigned int x_pixels<_ax>, unsigned char blur_flag<_bl> );
 
-extern unsigned int __fastcall __xsafe __macro vram_addr( unsigned char bat_x<_al>, unsigned char bat_y<_ah> );
-extern unsigned int __fastcall __xsafe __macro sgx_vram_addr( unsigned char bat_x<_al>, unsigned char bat_y<_ah> );
+extern unsigned int __fastcall __macro vram_addr( unsigned char bat_x<_al>, unsigned char bat_y<_ah> );
+extern unsigned int __fastcall __macro sgx_vram_addr( unsigned char bat_x<_al>, unsigned char bat_y<_ah> );
 
-extern unsigned int __fastcall __xsafe __macro get_vram( unsigned int address<_di> );
-extern unsigned int __fastcall __xsafe __macro sgx_get_vram( unsigned int address<_di> );
+extern unsigned int __fastcall __macro get_vram( unsigned int address<_di> );
+extern unsigned int __fastcall __macro sgx_get_vram( unsigned int address<_di> );
 
-extern void __fastcall __xsafe __macro put_vram( unsigned int address<_di>, unsigned int data<acc> );
-extern void __fastcall __xsafe __macro sgx_put_vram( unsigned int address<_di>, unsigned int data<acc> );
+extern void __fastcall __macro put_vram( unsigned int address<_di>, unsigned int data<acc> );
+extern void __fastcall __macro sgx_put_vram( unsigned int address<_di>, unsigned int data<acc> );
 
 extern void __fastcall set_tile_address( unsigned int vram<acc> );
 extern void __fastcall sgx_set_tile_address( unsigned int vram<acc> );
 
-extern void __fastcall __xsafe __nop set_tile_data( unsigned char __far *tiles<vdc_tile_bank:vdc_tile_addr>, unsigned char num_tiles<vdc_num_tiles>, unsigned char __far *palette_table<vdc_attr_bank:vdc_attr_addr>, unsigned char tile_type<vdc_tile_type> );
-extern void __fastcall __xsafe __nop sgx_set_tile_data( unsigned char __far *tiles<sgx_tile_bank:sgx_tile_addr>, unsigned char num_tiles<sgx_num_tiles>, unsigned char __far *palette_table<sgx_attr_bank:sgx_attr_addr>, unsigned char tile_type<sgx_tile_type> );
+extern void __fastcall __nop set_tile_data( unsigned char __far *tiles<vdc_tile_bank:vdc_tile_addr>, unsigned char num_tiles<vdc_num_tiles>, unsigned char __far *palette_table<vdc_attr_bank:vdc_attr_addr>, unsigned char tile_type<vdc_tile_type> );
+extern void __fastcall __nop sgx_set_tile_data( unsigned char __far *tiles<sgx_tile_bank:sgx_tile_addr>, unsigned char num_tiles<sgx_num_tiles>, unsigned char __far *palette_table<sgx_attr_bank:sgx_attr_addr>, unsigned char tile_type<sgx_tile_type> );
 
-extern void __fastcall __xsafe __nop set_far_tile_data( unsigned char tile_bank<vdc_tile_bank>, unsigned char *tile_addr<vdc_tile_addr>, unsigned char num_tiles<vdc_num_tiles>, unsigned char palette_table_bank<vdc_attr_bank>, unsigned char *palette_table_addr<vdc_attr_addr>, unsigned char tile_type<vdc_tile_type> );
-extern void __fastcall __xsafe __nop sgx_set_far_tile_data( unsigned char tile_bank<vdc_tile_bank>, unsigned char *tile_addr<vdc_tile_addr>, unsigned char num_tiles<vdc_num_tiles>, unsigned char palette_table_bank<vdc_attr_bank>, unsigned char *palette_table_addr<vdc_attr_addr>, unsigned char tile_type<vdc_tile_type> );
+extern void __fastcall __nop set_far_tile_data( unsigned char tile_bank<vdc_tile_bank>, unsigned char *tile_addr<vdc_tile_addr>, unsigned char num_tiles<vdc_num_tiles>, unsigned char palette_table_bank<vdc_attr_bank>, unsigned char *palette_table_addr<vdc_attr_addr>, unsigned char tile_type<vdc_tile_type> );
+extern void __fastcall __nop sgx_set_far_tile_data( unsigned char tile_bank<vdc_tile_bank>, unsigned char *tile_addr<vdc_tile_addr>, unsigned char num_tiles<vdc_num_tiles>, unsigned char palette_table_bank<vdc_attr_bank>, unsigned char *palette_table_addr<vdc_attr_addr>, unsigned char tile_type<vdc_tile_type> );
 
-extern void __fastcall __xsafe load_vram( unsigned int vram<_di>, unsigned char __far *data<_bp_bank:_bp>, unsigned int num_words<_ax> );
-extern void __fastcall __xsafe sgx_load_vram( unsigned int vram<_di>, unsigned char __far *data<_bp_bank:_bp>, unsigned int num_words<_ax> );
+extern void __fastcall load_vram( unsigned int vram<_di>, unsigned char __far *data<_bp_bank:_bp>, unsigned int num_words<_ax> );
+extern void __fastcall sgx_load_vram( unsigned int vram<_di>, unsigned char __far *data<_bp_bank:_bp>, unsigned int num_words<_ax> );
 
-extern void __fastcall __xsafe load_tile( unsigned int vram<_di> );
-extern void __fastcall __xsafe sgx_load_tile( unsigned int vram<_di> );
+extern void __fastcall load_tile( unsigned int vram<_di> );
+extern void __fastcall sgx_load_tile( unsigned int vram<_di> );
 
-extern void __fastcall __xsafe load_bat( unsigned int vram<_di>, unsigned char __far *data<_bp_bank:_bp>, unsigned char tiles_w<_al>, unsigned char tiles_h<_ah> );
-extern void __fastcall __xsafe sgx_load_bat( unsigned int vram<_di>, unsigned char __far *data<_bp_bank:_bp>, unsigned char tiles_w<_al>, unsigned char tiles_h<_ah> );
+extern void __fastcall load_bat( unsigned int vram<_di>, unsigned char __far *data<_bp_bank:_bp>, unsigned char tiles_w<_al>, unsigned char tiles_h<_ah> );
+extern void __fastcall sgx_load_bat( unsigned int vram<_di>, unsigned char __far *data<_bp_bank:_bp>, unsigned char tiles_w<_al>, unsigned char tiles_h<_ah> );
 
-extern void __fastcall __xsafe load_palette( unsigned char palette<_al>, unsigned char __far *data<_bp_bank:_bp>, unsigned char num_palettes<_ah> );
+extern void __fastcall load_palette( unsigned char palette<_al>, unsigned char __far *data<_bp_bank:_bp>, unsigned char num_palettes<_ah> );
 
-extern void __fastcall __xsafe set_font_addr( unsigned int vram<acc> );
-extern void __fastcall __xsafe set_font_pal( unsigned char palette<acc> );
+extern void __fastcall set_font_addr( unsigned int vram<acc> );
+extern void __fastcall set_font_pal( unsigned char palette<acc> );
 
-extern void __fastcall __xsafe load_font( char __far *font<_bp_bank:_bp>, unsigned char count<_al> );
-extern void __fastcall __xsafe load_font( char __far *font<_bp_bank:_bp>, unsigned char count<_al>, unsigned int vram<acc> );
+extern void __fastcall load_font( char __far *font<_bp_bank:_bp>, unsigned char count<_al> );
+extern void __fastcall load_font( char __far *font<_bp_bank:_bp>, unsigned char count<_al>, unsigned int vram<acc> );
 
-extern void __fastcall __xsafe __nop set_font_color( unsigned char foreground<monofont_fg>, unsigned char background<monofont_bg> );
-extern void __fastcall __xsafe load_default_font( void );
+extern void __fastcall __nop set_font_color( unsigned char foreground<monofont_fg>, unsigned char background<monofont_bg> );
+extern void __fastcall load_default_font( void );
 
-extern void __fastcall __xsafe put_char( unsigned char digit<_bl>, unsigned char bat_x<_dil>, unsigned char bat_y<_dih> );
-extern void __fastcall __xsafe put_digit( unsigned char digit<_bl>, unsigned char bat_x<_dil>, unsigned char bat_y<_dih> );
-extern void __fastcall __xsafe put_hex( unsigned int number<_bx>, unsigned char length<_cl>, unsigned char bat_x<_dil>, unsigned char bat_y<_dih> );
-extern void __fastcall __xsafe put_number( unsigned int number<_bx>, unsigned char length<_cl>, unsigned char bat_x<_dil>, unsigned char bat_y<_dih> );
-extern void __fastcall __xsafe put_raw( unsigned int data<_bx>, unsigned char bat_x<_dil>, unsigned char bat_y<_dih> );
-extern void __fastcall __xsafe put_string( unsigned char *string<_bp>, unsigned char bat_x<_dil>, unsigned char bat_y<_dih> );
+extern void __fastcall put_char( unsigned char digit<_bl>, unsigned char bat_x<_dil>, unsigned char bat_y<_dih> );
+extern void __fastcall put_digit( unsigned char digit<_bl>, unsigned char bat_x<_dil>, unsigned char bat_y<_dih> );
+extern void __fastcall put_hex( unsigned int number<_bx>, unsigned char length<_cl>, unsigned char bat_x<_dil>, unsigned char bat_y<_dih> );
+extern void __fastcall put_number( unsigned int number<_bx>, unsigned char length<_cl>, unsigned char bat_x<_dil>, unsigned char bat_y<_dih> );
+extern void __fastcall put_raw( unsigned int data<_bx>, unsigned char bat_x<_dil>, unsigned char bat_y<_dih> );
+extern void __fastcall put_string( unsigned char *string<_bp>, unsigned char bat_x<_dil>, unsigned char bat_y<_dih> );
 
-extern void __fastcall cls( void ); /* NOT __xsafe! */
-extern void __fastcall cls( unsigned int tile<acc> ); /* NOT __xsafe! */
+extern void __fastcall cls( void );
+extern void __fastcall cls( unsigned int tile<acc> );
 
-extern void __fastcall __xsafe disp_on( void );
-extern void __fastcall __xsafe disp_off( void );
+extern void __fastcall disp_on( void );
+extern void __fastcall disp_off( void );
 
-// extern void __fastcall __xsafe __nop set_far_base( unsigned char data_bank<_bp_bank>, unsigned char *data_addr<_bp> );
-// extern void __fastcall __xsafe set_far_offset( unsigned int offset<_bp>, unsigned char data_bank<_bp_bank>, unsigned char *data_addr<acc> );
+// extern void __fastcall __nop set_far_base( unsigned char data_bank<_bp_bank>, unsigned char *data_addr<_bp> );
+// extern void __fastcall set_far_offset( unsigned int offset<_bp>, unsigned char data_bank<_bp_bank>, unsigned char *data_addr<acc> );
 
-extern void __fastcall __xsafe far_load_vram( unsigned int vram<_di>,  unsigned int num_words<_ax> );
-extern void __fastcall __xsafe sgx_far_load_vram( unsigned int vram<_di>, unsigned int num_words<_ax> );
+extern void __fastcall far_load_vram( unsigned int vram<_di>,  unsigned int num_words<_ax> );
+extern void __fastcall sgx_far_load_vram( unsigned int vram<_di>, unsigned int num_words<_ax> );
 
-extern void __fastcall __xsafe far_load_bat( unsigned int vram<_di>, unsigned char tiles_w<_al>, unsigned char tiles_h<_ah> );
-extern void __fastcall __xsafe sgx_far_load_bat( unsigned int vram<_di>, unsigned char tiles_w<_al>, unsigned char tiles_h<_ah> );
+extern void __fastcall far_load_bat( unsigned int vram<_di>, unsigned char tiles_w<_al>, unsigned char tiles_h<_ah> );
+extern void __fastcall sgx_far_load_bat( unsigned int vram<_di>, unsigned char tiles_w<_al>, unsigned char tiles_h<_ah> );
 
-extern void __fastcall __xsafe far_load_palette( unsigned char palette<_al>, unsigned char num_palettes<_ah> );
-extern void __fastcall __xsafe far_load_font( unsigned char count<_al>, unsigned int vram<acc> );
+extern void __fastcall far_load_palette( unsigned char palette<_al>, unsigned char num_palettes<_ah> );
+extern void __fastcall far_load_font( unsigned char count<_al>, unsigned int vram<acc> );
 
 // Deprecated functions ...
 
-extern void __fastcall __xsafe load_background( unsigned char __far *tiles<_bp_bank:_bp>, unsigned char __far *palettes<__fbank:__fptr>, unsigned char __far *bat<_cl:_bx>, unsigned char w<_dl>, unsigned char h<_dh> );
-extern void __fastcall __xsafe set_tile_data( unsigned char *tile_ex<_di> );
-extern void __fastcall __xsafe __macro set_bgpal( unsigned char palette<_al>, unsigned char __far *data<_bp_bank:_bp> );
-extern void __fastcall __xsafe __macro set_bgpal( unsigned char palette<_al>, unsigned char __far *data<_bp_bank:_bp>, unsigned int num_palettes<_ah> );
-extern void __fastcall __xsafe __macro set_sprpal( unsigned char palette<_al>, unsigned char __far *data<_bp_bank:_bp> );
-extern void __fastcall __xsafe __macro set_sprpal( unsigned char palette<_al>, unsigned char __far *data<_bp_bank:_bp>, unsigned int num_palettes<_ah> );
+extern void __fastcall load_background( unsigned char __far *tiles<_bp_bank:_bp>, unsigned char __far *palettes<__fbank:__fptr>, unsigned char __far *bat<_cl:_bx>, unsigned char w<_dl>, unsigned char h<_dh> );
+extern void __fastcall set_tile_data( unsigned char *tile_ex<_di> );
+extern void __fastcall __macro set_bgpal( unsigned char palette<_al>, unsigned char __far *data<_bp_bank:_bp> );
+extern void __fastcall __macro set_bgpal( unsigned char palette<_al>, unsigned char __far *data<_bp_bank:_bp>, unsigned int num_palettes<_ah> );
+extern void __fastcall __macro set_sprpal( unsigned char palette<_al>, unsigned char __far *data<_bp_bank:_bp> );
+extern void __fastcall __macro set_sprpal( unsigned char palette<_al>, unsigned char __far *data<_bp_bank:_bp>, unsigned int num_palettes<_ah> );
 
 #endif // __HUCC__
 

--- a/include/hucc/hucc-old-line.asm
+++ b/include/hucc/hucc-old-line.asm
@@ -20,7 +20,7 @@
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe gfx_init( unsigned int start_vram_addr<_ax> );
+; void __fastcall gfx_init( unsigned int start_vram_addr<_ax> );
 ;
 ; initialize graphics mode
 ; - points graphics map to tiles at start_vram_addr
@@ -71,7 +71,7 @@ _gfx_init.1	.proc
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe gfx_clear( unsigned int start_vram_addr<_di> );
+; void __fastcall gfx_clear( unsigned int start_vram_addr<_di> );
 ;
 ; Clear the values in the graphics tiles
 ; - places zeroes in graphics tiles at start_vram_addr
@@ -107,7 +107,7 @@ _gfx_clear.1	.proc
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe gfx_line( unsigned int x1<_gfx_x1>, unsigned int y1<_gfx_y1>, unsigned int x2<_gfx_x2>, unsigned int y2<_gfx_y2>, unsigned char color<_gfx_color> );
+; void __fastcall gfx_line( unsigned int x1<_gfx_x1>, unsigned int y1<_gfx_y1>, unsigned int x2<_gfx_x2>, unsigned int y2<_gfx_y2>, unsigned char color<_gfx_color> );
 
 huc_gfx_line	.procgroup
 
@@ -446,7 +446,7 @@ _gfx_xdir	=	__fptr + 1
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe gfx_plot( unsigned int x<_gfx_x1>, unsigned int y<_gfx_y1>, char color<_gfx_color> );
+; void __fastcall gfx_plot( unsigned int x<_gfx_x1>, unsigned int y<_gfx_y1>, char color<_gfx_color> );
 
 _gfx_plot.3:	.proc
 

--- a/include/hucc/hucc-old-line.h
+++ b/include/hucc/hucc-old-line.h
@@ -26,10 +26,10 @@
 
 #asmdef	HUCC_USES_OLD_LINE 1
 
-extern void __fastcall __xsafe gfx_init( unsigned int start_vram_addr<_ax> );
-extern void __fastcall __xsafe gfx_clear( unsigned int start_vram_addr<_di> );
-extern void __fastcall __xsafe gfx_plot( unsigned int x<_gfx_x1>, unsigned int y<_gfx_y1>, char color<_gfx_color> );
-extern void __fastcall __xsafe gfx_line( unsigned int x1<_gfx_x1>, unsigned int y1<_gfx_y1>, unsigned int x2<_gfx_x2>, unsigned int y2<_gfx_y2>, unsigned char color<_gfx_color> );
+extern void __fastcall gfx_init( unsigned int start_vram_addr<_ax> );
+extern void __fastcall gfx_clear( unsigned int start_vram_addr<_di> );
+extern void __fastcall gfx_plot( unsigned int x<_gfx_x1>, unsigned int y<_gfx_y1>, char color<_gfx_color> );
+extern void __fastcall gfx_line( unsigned int x1<_gfx_x1>, unsigned int y1<_gfx_y1>, unsigned int x2<_gfx_x2>, unsigned int y2<_gfx_y2>, unsigned char color<_gfx_color> );
 
 #endif // __HUCC__
 

--- a/include/hucc/hucc-old-map.asm
+++ b/include/hucc/hucc-old-map.asm
@@ -20,8 +20,8 @@
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe load_map( unsigned char bat_x<_al>, unsigned char bat_y<_ah>, int map_x<_bx>, int map_y<_dx>, unsigned char tiles_w<_cl>, unsigned char tiles_h<_ch> );
-; void __fastcall __xsafe sgx_load_map( unsigned char bat_x<_al>, unsigned char bat_y<_ah>, int map_x<_bx>, int map_y<_dx>, unsigned char tiles_w<_cl>, unsigned char tiles_h<_ch> );
+; void __fastcall load_map( unsigned char bat_x<_al>, unsigned char bat_y<_ah>, int map_x<_bx>, int map_y<_dx>, unsigned char tiles_w<_cl>, unsigned char tiles_h<_ch> );
+; void __fastcall sgx_load_map( unsigned char bat_x<_al>, unsigned char bat_y<_ah>, int map_x<_bx>, int map_y<_dx>, unsigned char tiles_w<_cl>, unsigned char tiles_h<_ch> );
 ;
 ; Transfer a HuC tiled map into the BAT in VRAM
 ;
@@ -578,8 +578,8 @@ sgx_spr_clr:	ds	1
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe map_put_tile( unsigned char map_x<_bl>, unsigned char map_y<_bh>, unsigned char tile<_al> );
-; void __fastcall __xsafe sgx_map_put_tile( unsigned char map_x<_bl>, unsigned char map_y<_bh>, unsigned char tile<_al> );
+; void __fastcall map_put_tile( unsigned char map_x<_bl>, unsigned char map_y<_bh>, unsigned char tile<_al> );
+; void __fastcall sgx_map_put_tile( unsigned char map_x<_bl>, unsigned char map_y<_bh>, unsigned char tile<_al> );
 
 	.if	SUPPORT_SGX
 
@@ -632,8 +632,8 @@ sgx_spr_clr:	ds	1
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe put_tile( unsigned char tile<_bl>, unsigned char bat_x<_al>, unsigned char bat_y<_ah> );
-; void __fastcall __xsafe sgx_put_tile( unsigned char tile<_bl>, unsigned char bat_x<_al>, unsigned char bat_y<_ah> );
+; void __fastcall put_tile( unsigned char tile<_bl>, unsigned char bat_x<_al>, unsigned char bat_y<_ah> );
+; void __fastcall sgx_put_tile( unsigned char tile<_bl>, unsigned char bat_x<_al>, unsigned char bat_y<_ah> );
 ;
 ; Transfer a single HuC map tile to the BAT in VRAM
 ;

--- a/include/hucc/hucc-old-map.h
+++ b/include/hucc/hucc-old-map.h
@@ -26,31 +26,31 @@
 
 #asmdef	HUCC_USES_OLD_MAP 1
 
-extern void __fastcall __xsafe __nop set_map_data( unsigned char __far *map<vdc_map_bank:vdc_map_addr>, unsigned char w<vdc_map_width>, unsigned char h<vdc_map_height> );
-extern void __fastcall __xsafe __nop sgx_set_map_data( unsigned char __far *map<sgx_map_bank:sgx_map_addr>, unsigned char w<sgx_map_width>, unsigned char h<sgx_map_height> );
+extern void __fastcall __nop set_map_data( unsigned char __far *map<vdc_map_bank:vdc_map_addr>, unsigned char w<vdc_map_width>, unsigned char h<vdc_map_height> );
+extern void __fastcall __nop sgx_set_map_data( unsigned char __far *map<sgx_map_bank:sgx_map_addr>, unsigned char w<sgx_map_width>, unsigned char h<sgx_map_height> );
 
-extern void __fastcall __xsafe __nop set_far_map_data( unsigned char map_bank<vdc_map_bank>, unsigned char *map_addr<vdc_map_addr>, unsigned char w<vdc_map_width>, unsigned char h<vdc_map_height> );
-extern void __fastcall __xsafe __nop sgx_set_far_map_data( unsigned char map_bank<vdc_map_bank>, unsigned char *map_addr<vdc_map_addr>, unsigned char w<sgx_map_width>, unsigned char h<sgx_map_height> );
+extern void __fastcall __nop set_far_map_data( unsigned char map_bank<vdc_map_bank>, unsigned char *map_addr<vdc_map_addr>, unsigned char w<vdc_map_width>, unsigned char h<vdc_map_height> );
+extern void __fastcall __nop sgx_set_far_map_data( unsigned char map_bank<vdc_map_bank>, unsigned char *map_addr<vdc_map_addr>, unsigned char w<sgx_map_width>, unsigned char h<sgx_map_height> );
 
-extern void __fastcall __xsafe load_map( unsigned char bat_x<_al>, unsigned char bat_y<_ah>, int map_x<_bx>, int map_y<_dx>, unsigned char tiles_w<_cl>, unsigned char tiles_h<_ch> );
-extern void __fastcall __xsafe sgx_load_map( unsigned char bat_x<_al>, unsigned char bat_y<_ah>, int map_x<_bx>, int map_y<_dx>, unsigned char tiles_w<_cl>, unsigned char tiles_h<_ch> );
+extern void __fastcall load_map( unsigned char bat_x<_al>, unsigned char bat_y<_ah>, int map_x<_bx>, int map_y<_dx>, unsigned char tiles_w<_cl>, unsigned char tiles_h<_ch> );
+extern void __fastcall sgx_load_map( unsigned char bat_x<_al>, unsigned char bat_y<_ah>, int map_x<_bx>, int map_y<_dx>, unsigned char tiles_w<_cl>, unsigned char tiles_h<_ch> );
 
 extern unsigned char __fastcall map_get_tile( unsigned char map_x<_bl>, unsigned char map_y<_bh> );
 extern unsigned char __fastcall sgx_map_get_tile( unsigned char map_x<_bl>, unsigned char map_y<_bh> );
 
-extern void __fastcall __xsafe map_put_tile( unsigned char map_x<_bl>, unsigned char map_y<_bh>, unsigned char tile<_al> );
-extern void __fastcall __xsafe sgx_map_put_tile( unsigned char map_x<_bl>, unsigned char map_y<_bh>, unsigned char tile<_al> );
+extern void __fastcall map_put_tile( unsigned char map_x<_bl>, unsigned char map_y<_bh>, unsigned char tile<_al> );
+extern void __fastcall sgx_map_put_tile( unsigned char map_x<_bl>, unsigned char map_y<_bh>, unsigned char tile<_al> );
 
-extern void __fastcall __xsafe put_tile( unsigned char tile<_bl>, unsigned char bat_x<_al>, unsigned char bat_y<_ah> );
-extern void __fastcall __xsafe sgx_put_tile( unsigned char tile<_bl>, unsigned char bat_x<_al>, unsigned char bat_y<_ah> );
+extern void __fastcall put_tile( unsigned char tile<_bl>, unsigned char bat_x<_al>, unsigned char bat_y<_ah> );
+extern void __fastcall sgx_put_tile( unsigned char tile<_bl>, unsigned char bat_x<_al>, unsigned char bat_y<_ah> );
 
 // Deprecated functions ...
 
-extern void __fastcall __xsafe __nop set_map_pals( unsigned char __far *palette_table<vdc_attr_bank:vdc_attr_addr> );
-extern void __fastcall __xsafe __nop set_map_tile_type( unsigned char tile_type<vdc_tile_type> );
+extern void __fastcall __nop set_map_pals( unsigned char __far *palette_table<vdc_attr_bank:vdc_attr_addr> );
+extern void __fastcall __nop set_map_tile_type( unsigned char tile_type<vdc_tile_type> );
 
-extern void __fastcall __xsafe __nop sgx_set_map_pals( unsigned char __far *palette_table<sgx_attr_bank:sgx_attr_addr> );
-extern void __fastcall __xsafe __nop sgx_set_map_tile_type( unsigned char tile_type<sgx_tile_type> );
+extern void __fastcall __nop sgx_set_map_pals( unsigned char __far *palette_table<sgx_attr_bank:sgx_attr_addr> );
+extern void __fastcall __nop sgx_set_map_tile_type( unsigned char tile_type<sgx_tile_type> );
 
 extern void __fastcall set_map_tile_base( unsigned int vram<acc> );
 extern void __fastcall sgx_set_map_tile_base( unsigned int vram<acc> );

--- a/include/hucc/hucc-old-scroll.asm
+++ b/include/hucc/hucc-old-scroll.asm
@@ -77,7 +77,7 @@ HUC_1ST_RCR	=	$144
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe scroll( unsigned char num<_al>, unsigned int x<_cx>, unsigned int y<_dx>, unsigned char top<_ah>, unsigned char bottom<_bl>, unsigned char disp<acc> );
+; void __fastcall scroll( unsigned char num<_al>, unsigned int x<_cx>, unsigned int y<_dx>, unsigned char top<_ah>, unsigned char bottom<_bl>, unsigned char disp<acc> );
 ;
 ; set screen scrolling
 
@@ -116,7 +116,7 @@ _scroll.6:	ldy	<_al			; Region number.
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe scroll_disable( unsigned char num<acc> );
+; void __fastcall scroll_disable( unsigned char num<acc> );
 ;
 ; disable screen scrolling for a scroll region
 

--- a/include/hucc/hucc-old-scroll.h
+++ b/include/hucc/hucc-old-scroll.h
@@ -39,8 +39,8 @@
 
 #asmdef	HUCC_USES_OLD_SCROLL 1
 
-extern void __fastcall __xsafe scroll( unsigned char num<_al>, unsigned int x<_cx>, unsigned int y<_dx>, unsigned char top<_ah>, unsigned char bottom<_bl>, unsigned char disp<acc> );
-extern void __fastcall __xsafe scroll_disable( unsigned char num<acc> );
+extern void __fastcall scroll( unsigned char num<_al>, unsigned int x<_cx>, unsigned int y<_dx>, unsigned char top<_ah>, unsigned char bottom<_bl>, unsigned char disp<acc> );
+extern void __fastcall scroll_disable( unsigned char num<acc> );
 
 #endif // __HUCC__
 

--- a/include/hucc/hucc-old-spr.asm
+++ b/include/hucc/hucc-old-spr.asm
@@ -63,11 +63,11 @@ sgx_spr_sat:	ds	512	; N.B. Directly after spr_sat!
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe init_satb( void );
-; void __fastcall __xsafe reset_satb( void );
+; void __fastcall init_satb( void );
+; void __fastcall reset_satb( void );
 ;
-; void __fastcall __xsafe sgx_init_satb( void );
-; void __fastcall __xsafe sgx_reset_satb( void );
+; void __fastcall sgx_init_satb( void );
+; void __fastcall sgx_reset_satb( void );
 
 _reset_satb:
 _init_satb:	cly
@@ -100,8 +100,8 @@ _sgx_init_satb:	cly
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe satb_update( void );
-; void __fastcall __xsafe sgx_satb_update( void );
+; void __fastcall satb_update( void );
+; void __fastcall sgx_satb_update( void );
 
 old_satb_group	.procgroup
 
@@ -194,7 +194,7 @@ old_satb_group	.procgroup
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe spr_set( unsigned char num<acc> );
+; void __fastcall spr_set( unsigned char num<acc> );
 
 _spr_set.1:	cmp	spr_max
 		bcc	!+
@@ -218,7 +218,7 @@ _spr_set.1:	cmp	spr_max
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe spr_hide( void );
+; void __fastcall spr_hide( void );
 
 _spr_hide:	ldy	#1
 		lda	[spr_ptr], y
@@ -231,7 +231,7 @@ _spr_hide:	ldy	#1
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe spr_show( void );
+; void __fastcall spr_show( void );
 
 _spr_show:	ldy	#1
 		lda	[spr_ptr], y
@@ -244,7 +244,7 @@ _spr_show:	ldy	#1
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe spr_x( unsigned int value<acc> );
+; void __fastcall spr_x( unsigned int value<acc> );
 
 _spr_x.1:	phy
 		clc
@@ -262,7 +262,7 @@ _spr_x.1:	phy
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe spr_y( unsigned int value<acc> );
+; void __fastcall spr_y( unsigned int value<acc> );
 
 _spr_y.1:	clc
 		adc	#64
@@ -278,7 +278,7 @@ _spr_y.1:	clc
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe spr_pattern( unsigned int vaddr<acc> );
+; void __fastcall spr_pattern( unsigned int vaddr<acc> );
 
 _spr_pattern.1:	sty	<__temp		;     zp=fedcba98 a=76543210
 		asl	a		; c=f zp=edcba987 a=6543210_
@@ -300,7 +300,7 @@ _spr_pattern.1:	sty	<__temp		;     zp=fedcba98 a=76543210
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe spr_ctrl( unsigned char mask<_al>, unsigned char value<acc> );
+; void __fastcall spr_ctrl( unsigned char mask<_al>, unsigned char value<acc> );
 
 _spr_ctrl.2:	and	<_al
 		sta	<__temp
@@ -317,7 +317,7 @@ _spr_ctrl.2:	and	<_al
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe spr_pal( unsigned char palette<acc> )
+; void __fastcall spr_pal( unsigned char palette<acc> )
 
 _spr_pal.1:	and	#$0F
 		sta	<__temp
@@ -333,7 +333,7 @@ _spr_pal.1:	and	#$0F
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe spr_pri( unsigned char priority<acc> )
+; void __fastcall spr_pri( unsigned char priority<acc> )
 
 _spr_pri.1:	cmp	#1
 		ldy	#6
@@ -349,7 +349,7 @@ _spr_pri.1:	cmp	#1
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned int __fastcall __xsafe spr_get_x( void );
+; unsigned int __fastcall spr_get_x( void );
 
 _spr_get_x:	sec
 		ldy	#2
@@ -368,7 +368,7 @@ _spr_get_x:	sec
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned int __fastcall __xsafe spr_get_y( void );
+; unsigned int __fastcall spr_get_y( void );
 
 _spr_get_y:	sec
 		lda	[spr_ptr]
@@ -388,7 +388,7 @@ _spr_get_y:	sec
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe sgx_spr_set( unsigned char num<acc> );
+; void __fastcall sgx_spr_set( unsigned char num<acc> );
 
 _sgx_spr_set.1:	cmp	sgx_spr_max
 		bcc	!+
@@ -412,7 +412,7 @@ _sgx_spr_set.1:	cmp	sgx_spr_max
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe sgx_spr_hide( void );
+; void __fastcall sgx_spr_hide( void );
 
 _sgx_spr_hide:	ldy	#1
 		lda	[sgx_spr_ptr], y
@@ -425,7 +425,7 @@ _sgx_spr_hide:	ldy	#1
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe sgx_spr_show( void );
+; void __fastcall sgx_spr_show( void );
 
 _sgx_spr_show:	ldy	#1
 		lda	[sgx_spr_ptr], y
@@ -438,7 +438,7 @@ _sgx_spr_show:	ldy	#1
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe sgx_spr_x( unsigned int value<acc> );
+; void __fastcall sgx_spr_x( unsigned int value<acc> );
 
 _sgx_spr_x.1:	phy
 		clc
@@ -456,7 +456,7 @@ _sgx_spr_x.1:	phy
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe sgx_spr_y( unsigned int value<acc> );
+; void __fastcall sgx_spr_y( unsigned int value<acc> );
 
 _sgx_spr_y.1:	clc
 		adc	#64
@@ -472,7 +472,7 @@ _sgx_spr_y.1:	clc
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe sgx_spr_pattern( unsigned int vaddr<acc> );
+; void __fastcall sgx_spr_pattern( unsigned int vaddr<acc> );
 
 _sgx_spr_pattern.1:
 		sty	<__temp		;     zp=fedcba98 a=76543210
@@ -495,7 +495,7 @@ _sgx_spr_pattern.1:
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe sgx_spr_ctrl( unsigned char mask<_al>, unsigned char value<acc> );
+; void __fastcall sgx_spr_ctrl( unsigned char mask<_al>, unsigned char value<acc> );
 
 _sgx_spr_ctrl.2:and	<_al
 		sta	<__temp
@@ -512,7 +512,7 @@ _sgx_spr_ctrl.2:and	<_al
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe sgx_spr_pal( unsigned char palette<acc> )
+; void __fastcall sgx_spr_pal( unsigned char palette<acc> )
 
 _sgx_spr_pal.1:	and	#$0F
 		sta	<__temp
@@ -528,7 +528,7 @@ _sgx_spr_pal.1:	and	#$0F
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe sgx_spr_pri( unsigned char priority<acc> )
+; void __fastcall sgx_spr_pri( unsigned char priority<acc> )
 
 _sgx_spr_pri.1:	cmp	#1
 		ldy	#6
@@ -544,7 +544,7 @@ _sgx_spr_pri.1:	cmp	#1
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned int __fastcall __xsafe sgx_spr_get_x( void );
+; unsigned int __fastcall sgx_spr_get_x( void );
 
 _sgx_spr_get_x:	sec
 		ldy	#2
@@ -563,7 +563,7 @@ _sgx_spr_get_x:	sec
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned int __fastcall __xsafe sgx_spr_get_y( void );
+; unsigned int __fastcall sgx_spr_get_y( void );
 
 _sgx_spr_get_y:	sec
 		lda	[sgx_spr_ptr]

--- a/include/hucc/hucc-old-spr.h
+++ b/include/hucc/hucc-old-spr.h
@@ -47,37 +47,37 @@
 
 #asmdef	HUCC_USES_OLD_SPR 1
 
-extern void __fastcall __xsafe init_satb( void );
-extern void __fastcall __xsafe reset_satb( void );
-extern void __fastcall __xsafe satb_update( void );
-extern void __fastcall __xsafe spr_set( unsigned char num<acc> );
-extern void __fastcall __xsafe spr_hide( void );
-extern void __fastcall __xsafe spr_show( void );
-extern void __fastcall __xsafe spr_x( unsigned int value<acc> );
-extern void __fastcall __xsafe spr_y( unsigned int value<acc> );
-extern void __fastcall __xsafe spr_pattern( unsigned int vaddr<acc> );
-extern void __fastcall __xsafe spr_ctrl( unsigned char mask<_al>, unsigned char value<acc> );
-extern void __fastcall __xsafe spr_pal( unsigned char palette<acc> );
-extern void __fastcall __xsafe spr_pri( unsigned char priority<acc> );
+extern void __fastcall init_satb( void );
+extern void __fastcall reset_satb( void );
+extern void __fastcall satb_update( void );
+extern void __fastcall spr_set( unsigned char num<acc> );
+extern void __fastcall spr_hide( void );
+extern void __fastcall spr_show( void );
+extern void __fastcall spr_x( unsigned int value<acc> );
+extern void __fastcall spr_y( unsigned int value<acc> );
+extern void __fastcall spr_pattern( unsigned int vaddr<acc> );
+extern void __fastcall spr_ctrl( unsigned char mask<_al>, unsigned char value<acc> );
+extern void __fastcall spr_pal( unsigned char palette<acc> );
+extern void __fastcall spr_pri( unsigned char priority<acc> );
 
-extern unsigned int __fastcall __xsafe spr_get_x( void );
-extern unsigned int __fastcall __xsafe spr_get_y( void );
+extern unsigned int __fastcall spr_get_x( void );
+extern unsigned int __fastcall spr_get_y( void );
 
-extern void __fastcall __xsafe sgx_init_satb( void );
-extern void __fastcall __xsafe sgx_reset_satb( void );
-extern void __fastcall __xsafe sgx_satb_update( void );
-extern void __fastcall __xsafe sgx_spr_set( unsigned char num<acc> );
-extern void __fastcall __xsafe sgx_spr_hide( void );
-extern void __fastcall __xsafe sgx_spr_show( void );
-extern void __fastcall __xsafe sgx_spr_x( unsigned int value<acc> );
-extern void __fastcall __xsafe sgx_spr_y( unsigned int value<acc> );
-extern void __fastcall __xsafe sgx_spr_pattern( unsigned int vaddr<acc> );
-extern void __fastcall __xsafe sgx_spr_ctrl( unsigned char mask<_al>, unsigned char value<acc> );
-extern void __fastcall __xsafe sgx_spr_pal( unsigned char palette<acc> );
-extern void __fastcall __xsafe sgx_spr_pri( unsigned char priority<acc> );
+extern void __fastcall sgx_init_satb( void );
+extern void __fastcall sgx_reset_satb( void );
+extern void __fastcall sgx_satb_update( void );
+extern void __fastcall sgx_spr_set( unsigned char num<acc> );
+extern void __fastcall sgx_spr_hide( void );
+extern void __fastcall sgx_spr_show( void );
+extern void __fastcall sgx_spr_x( unsigned int value<acc> );
+extern void __fastcall sgx_spr_y( unsigned int value<acc> );
+extern void __fastcall sgx_spr_pattern( unsigned int vaddr<acc> );
+extern void __fastcall sgx_spr_ctrl( unsigned char mask<_al>, unsigned char value<acc> );
+extern void __fastcall sgx_spr_pal( unsigned char palette<acc> );
+extern void __fastcall sgx_spr_pri( unsigned char priority<acc> );
 
-extern unsigned int __fastcall __xsafe sgx_spr_get_x( void );
-extern unsigned int __fastcall __xsafe sgx_spr_get_y( void );
+extern unsigned int __fastcall sgx_spr_get_x( void );
+extern unsigned int __fastcall sgx_spr_get_y( void );
 
 #endif // __HUCC__
 

--- a/include/hucc/hucc-scroll.asm
+++ b/include/hucc/hucc-scroll.asm
@@ -58,8 +58,8 @@ HUCC_SCR_HEIGHT	=	224
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe scroll_split( unsigned char index<_al>, unsigned char screen_line<_ah>, unsigned int bat_x<_bx>, unsigned int bat_y<_cx>, unsigned char display_flags<_dl> );
-; void __fastcall __xsafe sgx_scroll_split( unsigned char index<_al>, unsigned char screen_line<_ah>, unsigned int bat_x<_bx>, unsigned int bat_y<_cx>, unsigned char display_flags<_dl> );
+; void __fastcall scroll_split( unsigned char index<_al>, unsigned char screen_line<_ah>, unsigned int bat_x<_bx>, unsigned int bat_y<_cx>, unsigned char display_flags<_dl> );
+; void __fastcall sgx_scroll_split( unsigned char index<_al>, unsigned char screen_line<_ah>, unsigned int bat_x<_bx>, unsigned int bat_y<_cx>, unsigned char display_flags<_dl> );
 ;
 ; set screen scrolling
 
@@ -244,8 +244,8 @@ HUCC_SCR_HEIGHT	=	224
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe disable_split( unsigned char index<acc> );
-; void __fastcall __xsafe sgx_disable_split( unsigned char index<acc> );
+; void __fastcall disable_split( unsigned char index<acc> );
+; void __fastcall sgx_disable_split( unsigned char index<acc> );
 ;
 ; disable screen scrolling for a scroll region
 

--- a/include/hucc/hucc-scroll.h
+++ b/include/hucc/hucc-scroll.h
@@ -53,14 +53,14 @@
 
 #asmdef	HUCC_USES_NEW_SCROLL 1
 
-extern void __fastcall __xsafe scroll_split( unsigned char index<_al>, unsigned char screen_line<_ah>, unsigned int bat_x<_bx>, unsigned int bat_y<_cx>, unsigned char display_flags<_dl> );
-extern void __fastcall __xsafe sgx_scroll_split( unsigned char index<_al>, unsigned char screen_line<_ah>, unsigned int bat_x<_bx>, unsigned int bat_y<_cx>, unsigned char display_flags<_dl> );
+extern void __fastcall scroll_split( unsigned char index<_al>, unsigned char screen_line<_ah>, unsigned int bat_x<_bx>, unsigned int bat_y<_cx>, unsigned char display_flags<_dl> );
+extern void __fastcall sgx_scroll_split( unsigned char index<_al>, unsigned char screen_line<_ah>, unsigned int bat_x<_bx>, unsigned int bat_y<_cx>, unsigned char display_flags<_dl> );
 
-extern void __fastcall __xsafe disable_split( unsigned char index<acc> );
-extern void __fastcall __xsafe sgx_disable_split( unsigned char index<acc> );
+extern void __fastcall disable_split( unsigned char index<acc> );
+extern void __fastcall sgx_disable_split( unsigned char index<acc> );
 
-extern void __fastcall __xsafe __macro disable_all_splits( void );
-extern void __fastcall __xsafe __macro sgx_disable_all_splits( void );
+extern void __fastcall __macro disable_all_splits( void );
+extern void __fastcall __macro sgx_disable_all_splits( void );
 
 #asm
 		.macro	_disable_all_splits

--- a/include/hucc/hucc-string.asm
+++ b/include/hucc/hucc-string.asm
@@ -45,21 +45,21 @@
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe strcpy( char *destination<_di>, char *source<_bp> );
-; void __fastcall __xsafe strcat( char *destination<_di>, char *source<_bp> );
+; void __fastcall strcpy( char *destination<_di>, char *source<_bp> );
+; void __fastcall strcat( char *destination<_di>, char *source<_bp> );
 ;
-; unsigned int __fastcall __xsafe strlcpy( char *destination<_di>, char *source<_bp>, unsigned char size<acc> );
-; unsigned int __fastcall __xsafe strlcat( char *destination<_di>, char *source<_bp>, unsigned char size<acc> );
-; unsigned int __fastcall __xsafe strlen( char *source<_bp> );
+; unsigned int __fastcall strlcpy( char *destination<_di>, char *source<_bp>, unsigned char size<acc> );
+; unsigned int __fastcall strlcat( char *destination<_di>, char *source<_bp>, unsigned char size<acc> );
+; unsigned int __fastcall strlen( char *source<_bp> );
 ;
 ; NOT WORKING YET (needs compiler changes) ...
 ;
-; void __fastcall __xsafe strcpy( char *destination<_di>, char __far *source<_bp_bank:_bp> );
-; void __fastcall __xsafe strcat( char *destination<_di>, char __far *source<_bp_bank:_bp> );
+; void __fastcall strcpy( char *destination<_di>, char __far *source<_bp_bank:_bp> );
+; void __fastcall strcat( char *destination<_di>, char __far *source<_bp_bank:_bp> );
 ;
-; unsigned int __fastcall __xsafe strlcpy( char *destination<_di>, char __far *source<_bp_bank:_bp>, unsigned char size<acc> );
-; unsigned int __fastcall __xsafe strlcat( char *destination<_di>, char __far *source<_bp_bank:_bp>, unsigned char size<acc> );
-; unsigned int __fastcall __xsafe strlen( char __far *source<_bp_bank:_bp> );
+; unsigned int __fastcall strlcpy( char *destination<_di>, char __far *source<_bp_bank:_bp>, unsigned char size<acc> );
+; unsigned int __fastcall strlcat( char *destination<_di>, char __far *source<_bp_bank:_bp>, unsigned char size<acc> );
+; unsigned int __fastcall strlen( char __far *source<_bp_bank:_bp> );
 
 _strcat:	cla				; Max string length == 256!
 		ldy.h	#256
@@ -192,12 +192,12 @@ str_exit:	tax				; X:Y = string or buffer length.
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe memcpy( unsigned char *destination<ram_tii_dst>, unsigned char  *source<ram_tii_src>, unsigned int count<acc> );
-; unsigned char * __fastcall __xsafe mempcpy( unsigned char *destination<ram_tii_dst>, unsigned char  *source<ram_tii_src>, unsigned int count<acc> );
+; void __fastcall memcpy( unsigned char *destination<ram_tii_dst>, unsigned char  *source<ram_tii_src>, unsigned int count<acc> );
+; unsigned char * __fastcall mempcpy( unsigned char *destination<ram_tii_dst>, unsigned char  *source<ram_tii_src>, unsigned int count<acc> );
 ;
 ; NOT WORKING YET (needs compiler changes) ...
-; void __fastcall __xsafe memcpy( unsigned char *destination<ram_tii_dst>, unsigned char __far *source<_bp_bank:ram_tii_src>, unsigned int count<acc> );
-; unsigned char * __fastcall __xsafe mempcpy( unsigned char *destination<ram_tii_dst>, unsigned char __far *source<_bp_bank:ram_tii_src>, unsigned int count<acc> );
+; void __fastcall memcpy( unsigned char *destination<ram_tii_dst>, unsigned char __far *source<_bp_bank:ram_tii_src>, unsigned int count<acc> );
+; unsigned char * __fastcall mempcpy( unsigned char *destination<ram_tii_dst>, unsigned char __far *source<_bp_bank:ram_tii_src>, unsigned int count<acc> );
 
 _memcpy:
 _mempcpy:	sty.h	ram_tii_len		; Check for zero length.
@@ -251,7 +251,7 @@ _mempcpy:	sty.h	ram_tii_len		; Check for zero length.
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe memset( unsigned char *destination<ram_tii_src>, unsigned char value<_al>, unsigned int count<acc> );
+; void __fastcall memset( unsigned char *destination<ram_tii_src>, unsigned char value<_al>, unsigned int count<acc> );
 
 _memset:	cmp	#0			; Decrement the length, check
 		bne	!+			; for zero and set C. 

--- a/include/hucc/hucc-string.h
+++ b/include/hucc/hucc-string.h
@@ -53,18 +53,18 @@
 
 #if 1
 
-extern void __fastcall __xsafe strcpy( char *destination<_di>, char *source<_bp> );
-extern void __fastcall __xsafe strcat( char *destination<_di>, char *source<_bp> );
+extern void __fastcall strcpy( char *destination<_di>, char *source<_bp> );
+extern void __fastcall strcat( char *destination<_di>, char *source<_bp> );
 
-extern unsigned int __fastcall __xsafe strlen( char *source<_bp> );
+extern unsigned int __fastcall strlen( char *source<_bp> );
 
-extern unsigned int __fastcall __xsafe strlcpy( char *destination<_di>, char *source<_bp>, unsigned char size<acc> );
-extern unsigned int __fastcall __xsafe strlcat( char *destination<_di>, char *source<_bp>, unsigned char size<acc> );
+extern unsigned int __fastcall strlcpy( char *destination<_di>, char *source<_bp>, unsigned char size<acc> );
+extern unsigned int __fastcall strlcat( char *destination<_di>, char *source<_bp>, unsigned char size<acc> );
 
-extern void __fastcall __xsafe memcpy( unsigned char *destination<ram_tii_dst>, unsigned char *source<ram_tii_src>, unsigned int count<acc> );
-extern unsigned char * __fastcall __xsafe mempcpy( unsigned char *destination<ram_tii_dst>, unsigned char *source<ram_tii_src>, unsigned int count<acc> );
+extern void __fastcall memcpy( unsigned char *destination<ram_tii_dst>, unsigned char *source<ram_tii_src>, unsigned int count<acc> );
+extern unsigned char * __fastcall mempcpy( unsigned char *destination<ram_tii_dst>, unsigned char *source<ram_tii_src>, unsigned int count<acc> );
 
-extern void __fastcall __xsafe memset( unsigned char *destination<ram_tii_src>, unsigned char value<_al>, unsigned int count<acc> );
+extern void __fastcall memset( unsigned char *destination<ram_tii_src>, unsigned char value<_al>, unsigned int count<acc> );
 
 extern int __fastcall strcmp( char *destination<_di>, char *source<_bp> );
 extern int __fastcall strncmp( char *destination<_di>, char *source<_bp>, unsigned int count<_ax> );
@@ -74,18 +74,18 @@ extern int __fastcall memcmp( unsigned char *destination<_di>, unsigned char *so
 
 /* NOT WORKING YET (needs compiler changes) ... */
 
-extern void __fastcall __xsafe strcpy( char *destination<_di>, char __far *source<_bp_bank:_bp> );
-extern void __fastcall __xsafe strcat( char *destination<_di>, char __far *source<_bp_bank:_bp> );
+extern void __fastcall strcpy( char *destination<_di>, char __far *source<_bp_bank:_bp> );
+extern void __fastcall strcat( char *destination<_di>, char __far *source<_bp_bank:_bp> );
 
-extern unsigned int __fastcall __xsafe strlen( char __far *source<_bp_bank:_bp> );
+extern unsigned int __fastcall strlen( char __far *source<_bp_bank:_bp> );
 
-extern unsigned int __fastcall __xsafe strlcpy( char *destination<_di>, char __far *source<_bp_bank:_bp>, unsigned char size<acc> );
-extern unsigned int __fastcall __xsafe strlcat( char *destination<_di>, char __far *source<_bp_bank:_bp>, unsigned char size<acc> );
+extern unsigned int __fastcall strlcpy( char *destination<_di>, char __far *source<_bp_bank:_bp>, unsigned char size<acc> );
+extern unsigned int __fastcall strlcat( char *destination<_di>, char __far *source<_bp_bank:_bp>, unsigned char size<acc> );
 
-extern void __fastcall __xsafe memcpy( unsigned char *destination<ram_tii_dst>, unsigned char __far *source<_bp_bank:ram_tii_src>, unsigned int count<acc> );
-extern unsigned char * __fastcall __xsafe mempcpy( unsigned char *destination<ram_tii_dst>, unsigned char __far *source<_bp_bank:ram_tii_src>, unsigned int count<acc> );
+extern void __fastcall memcpy( unsigned char *destination<ram_tii_dst>, unsigned char __far *source<_bp_bank:ram_tii_src>, unsigned int count<acc> );
+extern unsigned char * __fastcall mempcpy( unsigned char *destination<ram_tii_dst>, unsigned char __far *source<_bp_bank:ram_tii_src>, unsigned int count<acc> );
 
-extern void __fastcall __xsafe memset( unsigned char *destination<ram_tii_src>, unsigned char value<_al>, unsigned int count<acc> );
+extern void __fastcall memset( unsigned char *destination<ram_tii_src>, unsigned char value<_al>, unsigned int count<acc> );
 
 extern int __fastcall strcmp( char *destination<_di>, char __far *source<_bp_bank:_bp> );
 extern int __fastcall strncmp( char *destination<_di>, char __far *source<_bp_bank:_bp>, unsigned int count<_ax> );

--- a/include/hucc/hucc-systemcard.asm
+++ b/include/hucc/hucc-systemcard.asm
@@ -69,7 +69,7 @@ __bm_error	.ds	1
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned int __fastcall __xsafe __macro cd_getver( void );
+; unsigned int __fastcall __macro cd_getver( void );
 
 _cd_getver	.macro
 		phx				; Preserve X (aka __sp).
@@ -84,7 +84,7 @@ _cd_getver	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe __macro cd_boot( void );
+; void __fastcall __macro cd_boot( void );
 
 _cd_boot	.macro
 		system	cd_boot
@@ -95,7 +95,7 @@ _cd_boot	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe __macro cd_reset( void );
+; void __fastcall __macro cd_reset( void );
 
 _cd_reset	.macro
 		phx				; Preserve X (aka __sp).
@@ -108,7 +108,7 @@ _cd_reset	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned char __fastcall __xsafe __macro cd_pause( void );
+; unsigned char __fastcall __macro cd_pause( void );
 
 _cd_pause	.macro
 		phx				; Preserve X (aka __sp).
@@ -122,7 +122,7 @@ _cd_pause	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe __macro cd_fade( unsigned char type<acc> );
+; void __fastcall __macro cd_fade( unsigned char type<acc> );
 ;
 ;   type = $00 -> cancel fade
 ;	   $08 -> PCM fadeout 6 seconds
@@ -440,7 +440,7 @@ _cd_loadbank.4	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned char __fastcall __xsafe __macro cd_status( unsigned char mode<acc> );
+; unsigned char __fastcall __macro cd_status( unsigned char mode<acc> );
 
 _cd_status.1	.macro
 		phx				; Preserve X (aka __sp).
@@ -454,7 +454,7 @@ _cd_status.1	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe __macro ad_reset( void );
+; void __fastcall __macro ad_reset( void );
 
 _ad_reset	.macro
 		phx				; Preserve X (aka __sp).
@@ -466,7 +466,7 @@ _ad_reset	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned char __fastcall __xsafe __macro ad_trans( unsigned char ovl_index<_cl>, unsigned int sect_offset<_si>, unsigned char nb_sectors<_dh>, unsigned int ad_addr<_bx> );
+; unsigned char __fastcall __macro ad_trans( unsigned char ovl_index<_cl>, unsigned int sect_offset<_si>, unsigned char nb_sectors<_dh>, unsigned int ad_addr<_bx> );
 
 _ad_trans.4	.macro
 		phx				; Preserve X (aka __sp).
@@ -490,7 +490,7 @@ _ad_trans.4	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe __macro ad_read( unsigned int ad_addr<_cx>, unsigned char mode<_dh>, unsigned int buf<_bx>, unsigned int bytes<_ax> );
+; void __fastcall __macro ad_read( unsigned int ad_addr<_cx>, unsigned char mode<_dh>, unsigned int buf<_bx>, unsigned int bytes<_ax> );
 
 _ad_read.4	.macro
 		phx				; Preserve X (aka __sp).
@@ -503,7 +503,7 @@ _ad_read.4	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe __macro ad_write( unsigned int ad_addr<_cx>, unsigned char mode<_dh>, unsigned int buf<_bx>, unsigned int bytes<_ax> );
+; void __fastcall __macro ad_write( unsigned int ad_addr<_cx>, unsigned char mode<_dh>, unsigned int buf<_bx>, unsigned int bytes<_ax> );
 
 _ad_write.4	.macro
 		phx				; Preserve X (aka __sp).
@@ -515,7 +515,7 @@ _ad_write.4	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned char __fastcall __xsafe __macro ad_play( unsigned int ad_addr<_bx>, unsigned int bytes<_ax>, unsigned char freq<_dh>, unsigned char mode<_dl> );
+; unsigned char __fastcall __macro ad_play( unsigned int ad_addr<_bx>, unsigned int bytes<_ax>, unsigned char freq<_dh>, unsigned char mode<_dl> );
 
 _ad_play.4	.macro
 		phx				; Preserve X (aka __sp).
@@ -529,7 +529,7 @@ _ad_play.4	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned char __fastcall __xsafe __macro ad_cplay( unsigned char ovl_index<_cl>, unsigned int sect_offset<_si>, unsigned int nb_sectors<_bx>, unsigned char freq<_dh> );
+; unsigned char __fastcall __macro ad_cplay( unsigned char ovl_index<_cl>, unsigned int sect_offset<_si>, unsigned int nb_sectors<_bx>, unsigned char freq<_dh> );
 
 _ad_cplay.4	.macro
 		phx				; Preserve X (aka __sp).
@@ -559,7 +559,7 @@ _ad_cplay.4	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe __macro ad_stop( void );
+; void __fastcall __macro ad_stop( void );
 
 _ad_stop	.macro
 		phx				; Preserve X (aka __sp).
@@ -572,7 +572,7 @@ _ad_stop	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned char __fastcall __xsafe __macro ad_stat( void );
+; unsigned char __fastcall __macro ad_stat( void );
 
 _ad_stat	.macro
 		phx				; Preserve X (aka __sp).
@@ -586,7 +586,7 @@ _ad_stat	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; void __fastcall __xsafe add_sectors( unsigned int sector_offset<acc> );
+; void __fastcall add_sectors( unsigned int sector_offset<acc> );
 
 _add_sectors:	clc
 		adc	<_dl
@@ -701,7 +701,7 @@ _bm_format	.proc
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned int __fastcall __xsafe __macro bm_free( void );
+; unsigned int __fastcall __macro bm_free( void );
 ;
 ; Returns (int) number of user bytes available in BRAM, or 0 if error.
 ;
@@ -725,7 +725,7 @@ _bm_free	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned char __fastcall __xsafe __macro bm_read( unsigned char *buffer<_bx>, unsigned char *name<_ax>, unsigned int offset<_dx>, unsigned int length<_cx> );
+; unsigned char __fastcall __macro bm_read( unsigned char *buffer<_bx>, unsigned char *name<_ax>, unsigned int offset<_dx>, unsigned int length<_cx> );
 ;
 ; Check for existence of BRAM file with a matching name
 ;
@@ -750,7 +750,7 @@ _bm_read.4	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned char __fastcall __xsafe __macro bm_write( unsigned char *buffer<_bx>, unsigned char *name<_ax>, unsigned int offset<_dx>, unsigned int length<_cx> );
+; unsigned char __fastcall __macro bm_write( unsigned char *buffer<_bx>, unsigned char *name<_ax>, unsigned int offset<_dx>, unsigned int length<_cx> );
 ;
 ; Given the name of a BRAM file, update some info inside of it
 ;
@@ -775,7 +775,7 @@ _bm_write.4	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned char __fastcall __xsafe __macro bm_delete( unsigned char *name<_ax> );
+; unsigned char __fastcall __macro bm_delete( unsigned char *name<_ax> );
 ;
 ; Delete the entry specified by the name provided
 ;
@@ -800,7 +800,7 @@ _bm_delete.1	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned char __fastcall __xsafe __macro bm_exist( unsigned char *name<_ax> );
+; unsigned char __fastcall __macro bm_exist( unsigned char *name<_ax> );
 ;
 ; Check for existence of BRAM file with a matching name
 ;
@@ -835,7 +835,7 @@ _bm_exist.1	.macro
 ; ***************************************************************************
 ; ***************************************************************************
 ;
-; unsigned char __fastcall __xsafe __macro bm_create( unsigned char *name<_ax>, unsigned int length<_cx> );
+; unsigned char __fastcall __macro bm_create( unsigned char *name<_ax>, unsigned int length<_cx> );
 ;
 ; Create a new BRAM file, given the name and size
 ;

--- a/include/hucc/hucc-systemcard.h
+++ b/include/hucc/hucc-systemcard.h
@@ -84,39 +84,39 @@
 
 #asmdef	HUCC_USES_SYSTEMCARD 1
 
-extern void __fastcall __xsafe __macro cd_boot( void );
-extern unsigned int __fastcall __xsafe __macro cd_getver( void );
-extern void __fastcall __xsafe __macro cd_reset( void );
-extern unsigned char __fastcall __xsafe __macro cd_pause( void );
-extern unsigned char __fastcall __xsafe cd_unpause( void );
-extern void __fastcall __xsafe __macro cd_fade( unsigned char type<acc> );
+extern void __fastcall __macro cd_boot( void );
+extern unsigned int __fastcall __macro cd_getver( void );
+extern void __fastcall __macro cd_reset( void );
+extern unsigned char __fastcall __macro cd_pause( void );
+extern unsigned char __fastcall cd_unpause( void );
+extern void __fastcall __macro cd_fade( unsigned char type<acc> );
 extern unsigned char __fastcall cd_playtrk( unsigned char start_track<_bx>, unsigned char end_track<_cx>, unsigned char mode<_dh> );
 extern unsigned char __fastcall cd_playmsf( unsigned char start_minute<_al>,  unsigned char start_second<_ah>,  unsigned char start_frame<_bl>, unsigned char end_minute<_cl>,  unsigned char end_second<_ch>,  unsigned char end_frame<_dl>,  unsigned char mode<_dh> );
 extern unsigned char __fastcall cd_loadvram( unsigned char ovl_index<_cl>, unsigned int sect_offset<_si>, unsigned int vramaddr<_bx>, unsigned int bytes<_ax> );
 extern unsigned char __fastcall cd_loaddata( unsigned char ovl_index<_cl>, unsigned int sect_offset<_si>, unsigned char __far *buffer<_bp_bank:_bp>, unsigned int bytes<__ptr> );
 extern unsigned char __fastcall cd_loadbank( unsigned char ovl_index<_cl>, unsigned int sect_offset<_si>, unsigned char bank<_bl>, unsigned int sectors<_al> );
-extern unsigned char __fastcall __xsafe __macro cd_status( unsigned char mode<acc> );
+extern unsigned char __fastcall __macro cd_status( unsigned char mode<acc> );
 
-extern void __fastcall __xsafe __macro ad_reset( void );
-extern unsigned char __fastcall __xsafe __macro ad_trans( unsigned char ovl_index<_cl>, unsigned int sect_offset<_si>, unsigned char nb_sectors<_dh>, unsigned int ad_addr<_bx> );
-extern void __fastcall __xsafe __macro ad_read( unsigned int ad_addr<_cx>, unsigned char mode<_dh>, unsigned int buf<_bx>, unsigned int bytes<_ax> );
-extern void __fastcall __xsafe __macro ad_write( unsigned int ad_addr<_cx>, unsigned char mode<_dh>, unsigned int buf<_bx>, unsigned int bytes<_ax> );
-extern unsigned char __fastcall __xsafe __macro ad_play( unsigned int ad_addr<_bx>, unsigned int bytes<_ax>, unsigned char freq<_dh>, unsigned char mode<_dl> );
-extern unsigned char __fastcall __xsafe __macro ad_cplay( unsigned char ovl_index<_cl>, unsigned int sect_offset<_si>, unsigned int nb_sectors<_bx>, unsigned char freq<_dh> );
-extern void __fastcall __xsafe __macro ad_stop( void );
-extern unsigned char __fastcall __xsafe __macro ad_stat( void );
+extern void __fastcall __macro ad_reset( void );
+extern unsigned char __fastcall __macro ad_trans( unsigned char ovl_index<_cl>, unsigned int sect_offset<_si>, unsigned char nb_sectors<_dh>, unsigned int ad_addr<_bx> );
+extern void __fastcall __macro ad_read( unsigned int ad_addr<_cx>, unsigned char mode<_dh>, unsigned int buf<_bx>, unsigned int bytes<_ax> );
+extern void __fastcall __macro ad_write( unsigned int ad_addr<_cx>, unsigned char mode<_dh>, unsigned int buf<_bx>, unsigned int bytes<_ax> );
+extern unsigned char __fastcall __macro ad_play( unsigned int ad_addr<_bx>, unsigned int bytes<_ax>, unsigned char freq<_dh>, unsigned char mode<_dl> );
+extern unsigned char __fastcall __macro ad_cplay( unsigned char ovl_index<_cl>, unsigned int sect_offset<_si>, unsigned int nb_sectors<_bx>, unsigned char freq<_dh> );
+extern void __fastcall __macro ad_stop( void );
+extern unsigned char __fastcall __macro ad_stat( void );
 
 extern unsigned char __fastcall bm_check( void );
 extern unsigned char __fastcall bm_format( void );
-extern unsigned int __fastcall __xsafe __macro bm_free( void );
-extern unsigned char __fastcall __xsafe __macro bm_read( unsigned char *buffer<_bx>, unsigned char *name<_ax>, unsigned int offset<_dx>, unsigned int length<_cx> );
-extern unsigned char __fastcall __xsafe __macro bm_write( unsigned char *buffer<_bx>, unsigned char *name<_ax>, unsigned int offset<_dx>, unsigned int length<_cx> );
-extern unsigned char __fastcall __xsafe __macro bm_delete( unsigned char *name<_ax> );
+extern unsigned int __fastcall __macro bm_free( void );
+extern unsigned char __fastcall __macro bm_read( unsigned char *buffer<_bx>, unsigned char *name<_ax>, unsigned int offset<_dx>, unsigned int length<_cx> );
+extern unsigned char __fastcall __macro bm_write( unsigned char *buffer<_bx>, unsigned char *name<_ax>, unsigned int offset<_dx>, unsigned int length<_cx> );
+extern unsigned char __fastcall __macro bm_delete( unsigned char *name<_ax> );
 
 // Deprecated functions ...
 
-extern unsigned char __fastcall __xsafe __macro bm_exist( unsigned char *name<_ax> );
-extern unsigned char __fastcall __xsafe __macro bm_create( unsigned char *name<_ax>, unsigned int length<_cx> );
+extern unsigned char __fastcall __macro bm_exist( unsigned char *name<_ax> );
+extern unsigned char __fastcall __macro bm_create( unsigned char *name<_ax>, unsigned int length<_cx> );
 
 // void __fastcall _xsafe add_sectors( unsigned int sector_offset<acc> );
 

--- a/include/hucc/hucc.asm
+++ b/include/hucc/hucc.asm
@@ -116,7 +116,9 @@ HUCC		=	1
 		.list
 		.mlist
 
-		;
+		; The hardware stack is used for expressions.
+
+__tos		=	$F8:2101, 255
 
 		.zp
 		.align	2
@@ -158,10 +160,6 @@ ___SDCC_m6502_ret5:	.ds	1
 ___SDCC_m6502_ret6:	.ds	1
 ___SDCC_m6502_ret7:	.ds	1
 	.endif
-
-		; This is the lo-byte of the value returned by a HuCC function.
-
-__hucc_ret	=	___SDCC_m6502_ret3
 
 		; HuCC keeps a realtime clock, updated in hucc_vbl.
 		;
@@ -304,8 +302,7 @@ core_main:	tma7				; Get the CORE_BANK.
 
 		call	_main			; Execute the HuCC program.
 
-		lda	<__hucc_ret		; Pass the exit code on, then
-		jmp	_exit.1			; hang if not running TGEMU.
+		jmp	_exit.1			; Pass the exit code on.
 
 .stack_fill:	db	$EA,$EA			; To make it easier to see.
 

--- a/src/hucc/code.c
+++ b/src/hucc/code.c
@@ -481,18 +481,6 @@ void gen_code (INS *tmp)
 		nl();
 		break;
 
-	case I_GETACC:
-		ol("__getacc");
-		break;
-
-	case I_SAVESP:
-		ol("__savesp");
-		break;
-
-	case I_LOADSP:
-		ol("__loadsp");
-		break;
-
 	case I_MODSP:
 		ot("__modsp");
 		if (type == T_LITERAL) {
@@ -504,6 +492,10 @@ void gen_code (INS *tmp)
 			outdec((int)data);
 		}
 		nl();
+		break;
+
+	case I_PUSHARG_WR:
+		ol("__pusharg.wr");
 		break;
 
 	case I_PUSH_WR:
@@ -597,9 +589,9 @@ void gen_code (INS *tmp)
 		break;
 
 	case I_CMP_WT:
-		ot("__cmp.wt\t");
+		ot("__");
 		outstr(compare2str[tmp->cmp_type]);
-		outstr("_w");
+		outstr("_w.wt");
 		nl();
 		break;
 
@@ -1066,33 +1058,6 @@ void gen_code (INS *tmp)
 		out_type(type, data);
 		nl();
 		break;
-
-//	case X_LDWA_S:
-//		ot("__ld.was\t");
-//		outsymbol((SYMBOL *)imm_data);
-//		outstr(", ");
-//		outdec((int)data);
-//		outlocal(tmp->sym);
-//		nl();
-//		break;
-//
-//	case X_LDBA_S:
-//		ot("__ld.bas\t");
-//		outsymbol((SYMBOL *)imm_data);
-//		outstr(", ");
-//		outdec((int)data);
-//		outlocal(tmp->sym);
-//		nl();
-//		break;
-//
-//	case X_LDUBA_S:
-//		ot("__ld.uas\t");
-//		outsymbol((SYMBOL *)imm_data);
-//		outstr(", ");
-//		outdec((int)data);
-//		outlocal(tmp->sym);
-//		nl();
-//		break;
 
 	/* i-codes for pre- and post- increment and decrement */
 
@@ -1577,22 +1542,6 @@ void gen_code (INS *tmp)
 		out_type(type, data);
 		nl();
 		break;
-
-//	case X_STWA_S:
-//		ot("__stwa_s\t");
-//		outsymbol((SYMBOL *)imm_data);
-//		outstr(", ");
-//		outdec((int)data);
-//		nl();
-//		break;
-//
-//	case X_STBA_S:
-//		ot("__stba_s\t");
-//		outsymbol((SYMBOL *)imm_data);
-//		outstr(", ");
-//		outdec((int)data);
-//		nl();
-//		break;
 
 	/* i-codes for extending a byte to a word */
 

--- a/src/hucc/defs.h
+++ b/src/hucc/defs.h
@@ -49,10 +49,8 @@ enum ICODE {
 
 	I_ENTER,
 	I_RETURN,
-	I_GETACC,
-	I_SAVESP,
-	I_LOADSP,
 	I_MODSP,
+	I_PUSHARG_WR,
 	I_PUSH_WR,
 	I_POP_WR,
 	I_SPUSH_WR,	/* push and pop on the hw-stack */
@@ -607,9 +605,8 @@ struct const_array {
 
 #define MAX_FASTCALL_ARGS 16
 #define FASTCALL_EXTRA    0x01  // bitmask values
-#define FASTCALL_XSAFE    0x02  // bitmask values
-#define FASTCALL_NOP      0x04  // bitmask values
-#define FASTCALL_MACRO    0x08  // bitmask values
+#define FASTCALL_NOP      0x02  // bitmask values
+#define FASTCALL_MACRO    0x04  // bitmask values
 
 struct fastcall {
 	struct fastcall *next;

--- a/src/hucc/expr.c
+++ b/src/hucc/expr.c
@@ -941,11 +941,11 @@ int heir11 (LVALUE *lval, int comma)
 			}
 			if (deferred) {
 #if ULI_NORECURSE
-				if ((ptr->storage & STORAGE) == AUTO && norecurse && glint(ptr) < 0) {
+				if ((ptr->storage & STORAGE) == AUTO && norecurse && ptr->offset < 0) {
 					/* XXX: bit of a memory leak, but whatever... */
 					SYMBOL * locsym = copysym(ptr);
 					if (NAMEALLOC <=
-						sprintf(locsym->name, "_%s_end - %d", current_fn, -glint(ptr)))
+						sprintf(locsym->name, "_%s_end - %d", current_fn, -ptr->offset))
 						error("norecurse local name too long");
 					locsym->linked = ptr;
 					out_ins(I_ADD_WI, T_SYMBOL, (intptr_t)locsym);

--- a/src/hucc/gen.c
+++ b/src/hucc/gen.c
@@ -67,7 +67,7 @@ void getloc (SYMBOL *sym)
 		out_ins(I_LD_WI, T_SYMBOL, (intptr_t)(sym->linked));
 	else {
 #if ULI_NORECURSE
-		value = glint(sym);
+		value = sym->offset;
 		if (norecurse && value < 0) {
 			/* XXX: bit of a memory leak, but whatever... */
 			SYMBOL * locsym = copysym(sym);
@@ -82,7 +82,7 @@ void getloc (SYMBOL *sym)
 			out_ins_sym(I_LEA_S, T_STACK, value, sym);
 		}
 #else
-		value = glint(sym) - stkp;
+		value = sym->offset - stkp;
 		out_ins_sym(I_LEA_S, T_STACK, value, sym);
 #endif
 	}
@@ -119,7 +119,6 @@ void putstk (char typeobj)
 		out_ins(I_ST_UPT, 0, 0);
 	else
 		out_ins(I_ST_WPT, 0, 0);
-	stkp = stkp + INTSIZE;
 }
 
 /*
@@ -176,16 +175,15 @@ void immed (int type, intptr_t data)
 void gpush (void)
 {
 	out_ins(I_PUSH_WR, T_VALUE, INTSIZE);
-	stkp = stkp - INTSIZE;
 }
 
 /*
- *	push the primary register onto the stack
+ *	push the primary register onto the argument stack
  *
  */
 void gpusharg (int size)
 {
-	out_ins(I_PUSH_WR, T_SIZE, size);
+	out_ins(I_PUSHARG_WR, T_SIZE, size);
 	stkp = stkp - size;
 }
 
@@ -196,7 +194,6 @@ void gpusharg (int size)
 void gpop (void)
 {
 	out_ins(I_POP_WR, 0, 0);
-	stkp = stkp + INTSIZE;
 }
 
 /*
@@ -311,7 +308,6 @@ void gadd (LVALUE *lval, LVALUE *lval2)
 	if (dbltest(lval2, lval))
 		out_ins(I_DOUBLE, 0, 0);
 	out_ins(I_ADD_WT, 0, 0);
-	stkp = stkp + INTSIZE;
 }
 
 /*
@@ -321,7 +317,6 @@ void gadd (LVALUE *lval, LVALUE *lval2)
 void gsub (void)
 {
 	out_ins(I_SUB_WT, 0, 0);
-	stkp = stkp + INTSIZE;
 }
 
 /*
@@ -336,7 +331,6 @@ void gmult (int is_unsigned)
 		out_ins(I_MUL_WT, 0, 0);
 	else
 		out_ins(I_MUL_WT, 0, 0);
-	stkp = stkp + INTSIZE;
 }
 
 void gmult_imm (int value)
@@ -355,7 +349,6 @@ void gdiv (int is_unsigned)
 		out_ins(I_UDIV_WT, 0, 0);
 	else
 		out_ins(I_SDIV_WT, 0, 0);
-	stkp = stkp + INTSIZE;
 }
 
 void gdiv_imm (int value)
@@ -377,7 +370,6 @@ void gmod (int is_unsigned)
 		out_ins(I_UMOD_WT, 0, 0);
 	else
 		out_ins(I_SMOD_WT, 0, 0);
-	stkp = stkp + INTSIZE;
 }
 
 /*
@@ -387,7 +379,6 @@ void gmod (int is_unsigned)
 void gor (void)
 {
 	out_ins(I_OR_WT, 0, 0);
-	stkp = stkp + INTSIZE;
 }
 
 /*
@@ -397,7 +388,6 @@ void gor (void)
 void gxor (void)
 {
 	out_ins(I_EOR_WT, 0, 0);
-	stkp = stkp + INTSIZE;
 }
 
 /*
@@ -407,7 +397,6 @@ void gxor (void)
 void gand (void)
 {
 	out_ins(I_AND_WT, 0, 0);
-	stkp = stkp + INTSIZE;
 }
 
 /*
@@ -422,7 +411,6 @@ void gasr (int is_unsigned)
 		out_ins(I_LSR_WT, 0, 0);
 	else
 		out_ins(I_ASR_WT, 0, 0);
-	stkp = stkp + INTSIZE;
 }
 
 /*
@@ -434,7 +422,6 @@ void gasr (int is_unsigned)
 void gasl (void)
 {
 	out_ins(I_ASL_WT, 0, 0);
-	stkp = stkp + INTSIZE;
 }
 
 /*
@@ -532,7 +519,6 @@ void geq (void)
 {
 	out_ins_cmp(I_CMP_WT, CMP_EQU);
 	out_ins(I_BOOLEAN, 0, 0);
-	stkp = stkp + INTSIZE;
 }
 
 /*
@@ -543,7 +529,6 @@ void gne (void)
 {
 	out_ins_cmp(I_CMP_WT, CMP_NEQ);
 	out_ins(I_BOOLEAN, 0, 0);
-	stkp = stkp + INTSIZE;
 }
 
 /*
@@ -554,7 +539,6 @@ void glt (void)
 {
 	out_ins_cmp(I_CMP_WT, CMP_SLT);
 	out_ins(I_BOOLEAN, 0, 0);
-	stkp = stkp + INTSIZE;
 }
 
 /*
@@ -565,7 +549,6 @@ void gle (void)
 {
 	out_ins_cmp(I_CMP_WT, CMP_SLE);
 	out_ins(I_BOOLEAN, 0, 0);
-	stkp = stkp + INTSIZE;
 }
 
 /*
@@ -576,7 +559,6 @@ void ggt (void)
 {
 	out_ins_cmp(I_CMP_WT, CMP_SGT);
 	out_ins(I_BOOLEAN, 0, 0);
-	stkp = stkp + INTSIZE;
 }
 
 /*
@@ -587,7 +569,6 @@ void gge (void)
 {
 	out_ins_cmp(I_CMP_WT, CMP_SGE);
 	out_ins(I_BOOLEAN, 0, 0);
-	stkp = stkp + INTSIZE;
 }
 
 /*
@@ -598,7 +579,6 @@ void gult (void)
 {
 	out_ins_cmp(I_CMP_WT, CMP_ULT);
 	out_ins(I_BOOLEAN, 0, 0);
-	stkp = stkp + INTSIZE;
 }
 
 /*
@@ -609,7 +589,6 @@ void gule (void)
 {
 	out_ins_cmp(I_CMP_WT, CMP_ULE);
 	out_ins(I_BOOLEAN, 0, 0);
-	stkp = stkp + INTSIZE;
 }
 
 /*
@@ -620,7 +599,6 @@ void gugt (void)
 {
 	out_ins_cmp(I_CMP_WT, CMP_UGT);
 	out_ins(I_BOOLEAN, 0, 0);
-	stkp = stkp + INTSIZE;
 }
 
 /*
@@ -631,7 +609,6 @@ void guge (void)
 {
 	out_ins_cmp(I_CMP_WT, CMP_UGE);
 	out_ins(I_BOOLEAN, 0, 0);
-	stkp = stkp + INTSIZE;
 }
 
 void scale_const (int type, int otag, int *size)

--- a/src/hucc/preproc.c
+++ b/src/hucc/preproc.c
@@ -297,9 +297,6 @@ FILE *open_include (void)
 void doasm (void)
 {
 	char * source;
-	/* Save the SP if this #asm section is inside a function */
-	if (fexitlab)
-		out_ins(I_SAVESP, 0, 0);
 	flush_ins();	/* David - optimize.c related */
 	ol(".dbg\tclear");
 	cmode = 0;
@@ -322,10 +319,6 @@ void doasm (void)
 		outstr(line);
 #endif
 		nl();
-	}
-	/* Restore the SP if this #asm section is inside a function */
-	if (fexitlab) {
-		out_ins(I_LOADSP, 0, 0);
 	}
 	/* Mark the end of the #asm section */
 	if (ctext) {

--- a/src/hucc/primary.c
+++ b/src/hucc/primary.c
@@ -297,7 +297,7 @@ int primary (LVALUE *lval, int comma, bool *deferred)
 			    (ptr->identity == VARIABLE && ptr->sym_type == CSTRUCT)) {
 				/* add array base address after index calculation */
 #if ULI_NORECURSE
-				if (/* ptr->identity == ARRAY && */ ch() == '[' && (ptr->storage & STORAGE) == AUTO && norecurse && glint(ptr) < 0)
+				if (/* ptr->identity == ARRAY && */ ch() == '[' && (ptr->storage & STORAGE) == AUTO && norecurse && ptr->offset < 0)
 					*deferred = true;
 				else
 #endif

--- a/src/hucc/sym.c
+++ b/src/hucc/sym.c
@@ -743,11 +743,6 @@ void multidef (char *sname)
 	nl();
 }
 
-int glint (SYMBOL *sym)
-{
-	return (sym->offset);
-}
-
 SYMBOL *copysym (SYMBOL *sym)
 {
 	SYMBOL *ptr = malloc(sizeof(SYMBOL));

--- a/src/hucc/sym.h
+++ b/src/hucc/sym.h
@@ -13,6 +13,5 @@ SYMBOL *addloc (char *sname, char id, char typ, int value, char stclass, int siz
 bool symname (char *sname);
 void illname (void);
 void multidef (char *sname);
-int glint (SYMBOL *sym);
 SYMBOL *copysym (SYMBOL *sym);
 #endif


### PR DESCRIPTION
This frees up the X register that HuCC used to use as a permanent stack pointer.