### PR TITLE
Add the ability to HuCC to remove repeated characters in a "#incchr" …

### DIFF
--- a/include/hucc/hucc-baselib.h
+++ b/include/hucc/hucc-baselib.h
@@ -85,6 +85,8 @@ extern unsigned char dh;
 
 #asmdef	HUCC_USES_BASELIB 1
 
+#define	_OPTIMIZE 1
+
 extern void __fastcall __nop set_far_base( unsigned char data_bank<_bp_bank>, unsigned char *data_addr<_bp> );
 extern void __fastcall set_far_offset( unsigned int offset<_bp>, unsigned char data_bank<_bp_bank>, unsigned char *data_addr<acc> );
 

--- a/src/hucc/pseudo.c
+++ b/src/hucc/pseudo.c
@@ -45,7 +45,7 @@ void dopsdinc (void)
 		readstr();	/* read the label name */
 		prefix();
 		outstr(litq2);
-		outstr(":\n");
+		outstr(":");
 		addglb_far(litq2, CINT);
 
 		if (!match(",")) {
@@ -58,7 +58,7 @@ void dopsdinc (void)
 
 		if (readqstr() == 0) {
 			/* read the filename */
-			error("bad filename in incpal");
+			error("bad filename in #incpal()");
 			kill();
 			return;
 		}
@@ -84,7 +84,7 @@ void dopsdinc (void)
 		ol(".code");
 
 		if (numericarg > 2)
-			error("Maximum 2 numeric arg for incpal(name,\"filename\" [,start_pal] [,nb_pal])");
+			error("Incorrect arguments for #incpal(label, \"filename\" [,start_pal [,nb_pal]])");
 
 		kill();
 	}
@@ -98,7 +98,7 @@ void dopsdinc (void)
 		readstr();	/* read the label name */
 		prefix();
 		outstr(litq2);
-		outstr(":\n");
+		outstr(":");
 		addglb_far(litq2, CUCHAR);
 
 		if (!match(",")) {
@@ -110,49 +110,12 @@ void dopsdinc (void)
 		ot(".incbin\t\t\"");
 		if (readqstr() == 0) {
 			/* read the filename */
-			error("bad filename in incbin");
+			error("bad filename in #incbin()");
 			kill();
 			return;
 		}
 		outstr(litq2);
 		outstr("\"\n");
-
-		if (!match(")"))
-			error("missing )");
-
-		nl();
-		ol(".code");
-		kill();
-	}
-	else
-	if (amatch("bat", 3)) {
-		if (!match("("))
-			error("missing (");
-
-		ol(".data");
-
-		readstr();	/* read the label name */
-		prefix();
-		outstr(litq2);
-		outstr(":\n");
-		addglb_far(litq2, CINT);
-
-		if (!match(",")) {
-			error("missing ,");
-			kill();
-			return;
-		}
-
-		ot(".incbat\t\t\"");
-
-		if (readqstr() == 0) {
-			error("bad filename in incbat");
-			kill();
-			return;
-		}
-
-		outstr(litq2);
-		outstr("\"");
 
 		if (match(","))
 			outstr(", ");
@@ -171,10 +134,132 @@ void dopsdinc (void)
 		nl();
 		ol(".code");
 
-		if ((numericarg != 1) &&
-		    (numericarg != 3) &&
-		    (numericarg != 5))
-			error("Either 1,3 or 5 numeric arguments are needed for incbat statement");
+		if (numericarg > 2)
+			error("Incorrect arguments for #incbin(label, \"filename\" [,offset [,length]])");
+
+		kill();
+	}
+	else
+	if (amatch("bat", 3)) {
+		if (!match("("))
+			error("missing (");
+
+		ol(".data");
+
+		readstr();	/* read the label name */
+		prefix();
+		outstr(litq2);
+		outstr(":");
+		addglb_far(litq2, CINT);
+
+		if (!match(",")) {
+			error("missing ,");
+			kill();
+			return;
+		}
+
+		ot(".incbat\t\t\"");
+
+		if (readqstr() == 0) {
+			error("bad filename in #incbat()");
+			kill();
+			return;
+		}
+
+		outstr(litq2);
+		outstr("\"");
+
+		if (match(","))
+			outstr(", ");
+
+		numericarg = 0;
+
+		while (!match(")")) {
+			numericarg++;
+
+			if (number(&dummy))
+				outdec(dummy);
+			else {
+				readstr();
+				prefix();
+				outstr(litq2);
+				if (!match(")"))
+					error("A #incchr() label can only be the final #incbat() argument!");
+				break;
+			}
+
+			if (match(","))
+				outstr(", ");
+		}
+
+		nl();
+		ol(".code");
+
+		if ((numericarg == 0) ||
+		    (numericarg >= 7))
+			error("Incorrect arguments for #incbat(label, \"filename\", addr, [[,x ,y] ,w ,h] [,chrset])");
+
+		kill();
+	}
+	else
+	if (amatch("map", 3)) {
+		if (!match("("))
+			error("missing (");
+
+		ol(".data");
+
+		readstr();	/* read the label name */
+		prefix();
+		outstr(litq2);
+		outstr(":");
+		addglb_far(litq2, CINT);
+
+		if (!match(",")) {
+			error("missing ,");
+			kill();
+			return;
+		}
+
+		ot(".incmap\t\t\"");
+
+		if (readqstr() == 0) {
+			error("bad filename in #incmap()");
+			kill();
+			return;
+		}
+
+		outstr(litq2);
+		outstr("\"");
+
+		if (match(","))
+			outstr(", ");
+
+		numericarg = 0;
+
+		while (!match(")")) {
+			numericarg++;
+
+			if (number(&dummy))
+				outdec(dummy);
+			else {
+				readstr();
+				prefix();
+				outstr(litq2);
+				if (!match(")"))
+					error("A #inctile()/#incchr() label can only be the final #incmap() argument!");
+				break;
+			}
+
+			if (match(","))
+				outstr(", ");
+		}
+
+		nl();
+		ol(".code");
+
+		if ((numericarg == 0) ||
+		    (numericarg >= 6))
+			error("Incorrect arguments for #incmap(label, \"filename\", [[,x ,y] ,w ,h] ,tileset)");
 
 		kill();
 	}
@@ -188,7 +273,7 @@ void dopsdinc (void)
 		readstr();	/* read the label name */
 		prefix();
 		outstr(litq2);
-		outstr(":\n");
+		outstr(":");
 		addglb_far(litq2, CINT);
 
 		if (!match(",")) {
@@ -200,7 +285,7 @@ void dopsdinc (void)
 		ot(".incspr\t\t\"");
 
 		if (readqstr() == 0) {
-			error("bad filename in incspr");
+			error("bad filename in #incspr()");
 			kill();
 			return;
 		}
@@ -228,7 +313,7 @@ void dopsdinc (void)
 		if ((numericarg != 0) &&
 		    (numericarg != 2) &&
 		    (numericarg != 4))
-			error("Either 0,2 or 4 numeric arguments are needed for incspr statement");
+			error("Incorrect arguments for #incspr(label, \"filename\", [[,x ,y] ,w ,h])");
 
 		kill();
 	}
@@ -242,7 +327,7 @@ void dopsdinc (void)
 		readstr();	/* read the label name */
 		prefix();
 		outstr(litq2);
-		outstr(":\n");
+		outstr(":");
 		addglb_far(litq2, CINT);
 
 		if (!match(",")) {
@@ -254,7 +339,7 @@ void dopsdinc (void)
 		ot(".incsprpal\t\"");
 
 		if (readqstr() == 0) {
-			error("bad filename in incsprpal");
+			error("bad filename in #incsprpal()");
 			kill();
 			return;
 		}
@@ -282,7 +367,7 @@ void dopsdinc (void)
 		if ((numericarg != 0) &&
 		    (numericarg != 2) &&
 		    (numericarg != 4))
-			error("Either 0,2 or 4 numeric arguments are needed for incsprpal statement");
+			error("Incorrect arguments for #incsprpal(label, \"filename\", [[,x ,y] ,w ,h])");
 
 		kill();
 	}
@@ -296,7 +381,7 @@ void dopsdinc (void)
 		readstr();	/* read the label name */
 		prefix();
 		outstr(litq2);
-		outstr(":\n");
+		outstr(": ");
 		addglb_far(litq2, CINT);
 
 		if (!match(",")) {
@@ -308,7 +393,7 @@ void dopsdinc (void)
 		ot(".incchr\t\t\"");
 
 		if (readqstr() == 0) {
-			error("bad filename in incchr");
+			error("bad filename in #incchr()");
 			kill();
 			return;
 		}
@@ -333,10 +418,8 @@ void dopsdinc (void)
 		nl();
 		ol(".code");
 
-		if ((numericarg != 0) &&
-		    (numericarg != 2) &&
-		    (numericarg != 4))
-			error("Either 0,2 or 4 numeric arguments are needed for incchr statement");
+		if (numericarg > 5)
+			error("Incorrect arguments for #incchr(label, \"filename\" [[,x ,y] ,w ,h] [,_OPTIMIZE])");
 
 		kill();
 	}
@@ -350,7 +433,7 @@ void dopsdinc (void)
 		readstr();	/* read the label name */
 		prefix();
 		outstr(litq2);
-		outstr(":\n");
+		outstr(":");
 		addglb_far(litq2, CINT);
 
 		if (!match(",")) {
@@ -362,7 +445,7 @@ void dopsdinc (void)
 		ot(".incchrpal\t\"");
 
 		if (readqstr() == 0) {
-			error("bad filename in incchrpal");
+			error("bad filename in #incchrpal()");
 			kill();
 			return;
 		}
@@ -390,7 +473,7 @@ void dopsdinc (void)
 		if ((numericarg != 0) &&
 		    (numericarg != 2) &&
 		    (numericarg != 4))
-			error("Either 0,2 or 4 numeric arguments are needed for incchrpal statement");
+			error("Incorrect arguments for #incchrpal(label, \"filename\", [[,x ,y] ,w ,h])");
 
 		kill();
 	}
@@ -407,7 +490,7 @@ void dopsdinc (void)
 		readstr();	/* read the label name */
 		prefix();
 		outstr(litq2);
-		outstr(":\n");
+		outstr(":");
 		addglb_far(litq2, CINT);
 
 		if (!match(",")) {
@@ -419,7 +502,7 @@ void dopsdinc (void)
 		ot(".inctile\t\"");
 
 		if (readqstr() == 0) {
-			error("bad filename in inctile");
+			error("bad filename in #inctile()");
 			kill();
 			return;
 		}
@@ -447,7 +530,7 @@ void dopsdinc (void)
 		if ((numericarg != 0) &&
 		    (numericarg != 2) &&
 		    (numericarg != 4))
-			error("Either 0,2 or 4 numeric arguments are needed for inctile statement");
+			error("Incorrect arguments for #inctile(label, \"filename\", [[,x ,y] ,w ,h])");
 
 		kill();
 	}
@@ -464,7 +547,7 @@ void dopsdinc (void)
 		readstr();	/* read the label name */
 		prefix();
 		outstr(litq2);
-		outstr(":\n");
+		outstr(":");
 		addglb_far(litq2, CINT);
 
 		if (!match(",")) {
@@ -476,7 +559,7 @@ void dopsdinc (void)
 		ot(".inctilepal\t\"");
 
 		if (readqstr() == 0) {
-			error("bad filename in inctilepal");
+			error("bad filename in #inctilepal()");
 			kill();
 			return;
 		}
@@ -504,7 +587,7 @@ void dopsdinc (void)
 		if ((numericarg != 0) &&
 		    (numericarg != 2) &&
 		    (numericarg != 4))
-			error("Either 0,2 or 4 numeric arguments are needed for inctilepal statement");
+			error("Incorrect arguments for #inctilepal(label, \"filename\", [[,x ,y] ,w ,h])");
 
 		kill();
 	}
@@ -533,7 +616,7 @@ void dopsdinc (void)
 
 		// Get the file name
 		if (readqstr() == 0) {
-			error("bad filename in incasm");
+			error("bad filename in #incasmlabel()");
 			kill();
 			return;
 		}
@@ -561,7 +644,7 @@ void dopsdinc (void)
 		// Output the label name:
 		prefix();
 		outstr(str_buf);
-		outstr(":\n");
+		outstr(":");
 
 		ot(".include\t\"");
 		outstr(litq2);
@@ -583,7 +666,7 @@ void dopsdinc (void)
 		ol(".data");
 
 		if (readqstr() == 0) {
-			error("bad filename in incasm");
+			error("bad filename in #incasm()");
 			kill();
 			return;
 		}
@@ -986,7 +1069,7 @@ void do_inc_ex (int type)
 	ol(".data");
 	prefix();
 	outstr(label2);
-	outstr(":\n");
+	outstr(":");
 	for (i = 0; i < num; i++) {
 		if (type == 8)
 			ot(".incchr\t\t\"");

--- a/src/mkit/as/atari.c
+++ b/src/mkit/as/atari.c
@@ -154,10 +154,6 @@ fuji_pack_8x8_tile(unsigned char *buffer, void *data, int line_offset, int forma
 	unsigned char *ptr;
 	unsigned int *packed;
 
-	/* pack the tile only in the last pass */
-	if (pass != LAST_PASS)
-		return (0);
-
 	/* clear buffer */
 	memset(buffer, 0, 16);
 

--- a/src/mkit/as/externs.h
+++ b/src/mkit/as/externs.h
@@ -8,6 +8,8 @@ extern int bank_loccnt[MAX_S][MAX_BANKS];
 extern int bank_page[MAX_S][MAX_BANKS];
 extern int bank_maxloc[MAX_BANKS];              /* record max location in bank */
 
+extern unsigned char workspace[65536];          /* buffer for .inc and .def directives */
+
 extern int discontiguous;                       /* NZ signals a warp in loccnt */
 extern int max_zp;                              /* higher used address in zero page */
 extern int max_bss;                             /* higher used address in ram */
@@ -43,6 +45,10 @@ extern int pcx_nb_args;                         /* number of argument */
 extern unsigned int pcx_arg[8];                 /* PCX args array */
 extern unsigned char *pcx_buf;                  /* pointer to the PCX buffer */
 extern unsigned char pcx_pal[256][3];           /* palette */
+extern unsigned int tile_offset;                /* offset in the tile reference table */
+extern struct t_tile tile[65536 / 32];          /* tile info table */
+extern struct t_tile *tile_tbl[HASH_COUNT];     /* tile hash table */
+extern struct t_symbol *tile_lablptr;           /* tile symbol reference */
 extern char *expr;                              /* expression string pointer */
 extern struct t_symbol *expr_toplabl;           /* pointer to the innermost scope-label */
 extern struct t_symbol *expr_lablptr;           /* pointer to the last-referenced label */

--- a/src/mkit/as/inst.h
+++ b/src/mkit/as/inst.h
@@ -197,6 +197,8 @@ struct t_opcode w65c02_inst[3] = {
 	{NULL, NULL, NULL, 0, 0, 0}
 };
 
+#define NARGS_0_1_2_3_5 0b11000000
+
 /* pseudo instruction table */
 struct t_opcode base_pseudo[] = {
 	{NULL,  "*",            do_star,        PSEUDO, P_ORG,     1},
@@ -231,7 +233,7 @@ struct t_opcode base_pseudo[] = {
 	{NULL,  "IFNDEF",       do_ifdef,       PSEUDO, P_IFNDEF,  0},
 	{NULL,  "INCBIN",       do_incbin,      PSEUDO, P_INCBIN,  0},
 	{NULL,  "INCLUDE",      do_include,     PSEUDO, P_INCLUDE, 0},
-	{NULL,  "INCCHR",       do_incchr,      PSEUDO, P_INCCHR,  0xEA},
+	{NULL,  "INCCHR",       do_incchr,      PSEUDO, P_INCCHR,  NARGS_0_1_2_3_5},
 	{NULL,  "LIST",         do_list,        PSEUDO, P_LIST,    0},
 	{NULL,  "MAC",          do_macro,       PSEUDO, P_MACRO,   0},
 	{NULL,  "MACRO",        do_macro,       PSEUDO, P_MACRO,   0},
@@ -277,7 +279,7 @@ struct t_opcode base_pseudo[] = {
 	{NULL, ".IFNDEF",       do_ifdef,       PSEUDO, P_IFNDEF,  0},
 	{NULL, ".INCBIN",       do_incbin,      PSEUDO, P_INCBIN,  0},
 	{NULL, ".INCLUDE",      do_include,     PSEUDO, P_INCLUDE, 0},
-	{NULL, ".INCCHR",       do_incchr,      PSEUDO, P_INCCHR,  0xEA},
+	{NULL, ".INCCHR",       do_incchr,      PSEUDO, P_INCCHR,  NARGS_0_1_2_3_5},
 	{NULL, ".LIST",         do_list,        PSEUDO, P_LIST,    0},
 	{NULL, ".MAC",          do_macro,       PSEUDO, P_MACRO,   0},
 	{NULL, ".MACRO",        do_macro,       PSEUDO, P_MACRO,   0},

--- a/src/mkit/as/nes.c
+++ b/src/mkit/as/nes.c
@@ -59,10 +59,6 @@ nes_pack_8x8_tile(unsigned char *buffer, void *data, int line_offset, int format
 	unsigned char *ptr;
 	unsigned int *packed;
 
-	/* pack the tile only in the last pass */
-	if (pass != LAST_PASS)
-		return (0);
-
 	/* clear buffer */
 	memset(buffer, 0, 16);
 
@@ -154,7 +150,8 @@ nes_defchr(int *ip)
 	}
 
 	/* encode tile */
-	nes_pack_8x8_tile(buffer, data, 0, PACKED_TILE);
+	if (pass == LAST_PASS)
+		nes_pack_8x8_tile(buffer, data, 0, PACKED_TILE);
 
 	/* store tile */
 	putbuffer(buffer, 16);

--- a/src/mkit/as/pce.h
+++ b/src/mkit/as/pce.h
@@ -69,34 +69,39 @@ struct t_opcode huc6280_inst[38] = {
 	{NULL, NULL, NULL, 0, 0, 0}
 };
 
+#define NARGS_0_1_2 0b11111000
+#define NARGS_0_2_4 0b11101010
+#define NARGS_1_3_5 0b11010101
+#define NARGS_1_2_3_4_5_6 0b10000001
+
 /* PCE specific pseudos */
 struct t_opcode pce_pseudo[29] = {
-	{NULL,  "DEFCHR",    pce_defchr,    PSEUDO, P_DEFCHR,    0},
-	{NULL,  "DEFPAL",    pce_defpal,    PSEUDO, P_DEFPAL,    0},
-	{NULL,  "DEFSPR",    pce_defspr,    PSEUDO, P_DEFSPR,    0},
-	{NULL,  "INCBAT",    pce_incbat,    PSEUDO, P_INCBAT,    0xD5},
-	{NULL,  "INCSPR",    pce_incspr,    PSEUDO, P_INCSPR,    0xEA},
-	{NULL,  "INCPAL",    pce_incpal,    PSEUDO, P_INCPAL,    0xF8},
-	{NULL,  "INCTILE",   pce_inctile,   PSEUDO, P_INCTILE,   0xEA},
-	{NULL,  "INCMAP",    pce_incmap,    PSEUDO, P_INCMAP,    0xD5},
-	{NULL,  "INCCHRPAL", pce_incchrpal, PSEUDO, P_INCCHRPAL, 0xEA},
-	{NULL, ".INCSPRPAL", pce_incsprpal, PSEUDO, P_INCSPRPAL, 0xEA},
-	{NULL,  "INCTILEPAL",pce_inctilepal,PSEUDO, P_INCTILEPAL,0xEA},
-	{NULL,  "MML",       pce_mml,       PSEUDO, P_MML,       0},
-	{NULL,  "PAL",       pce_pal,       PSEUDO, P_PAL,       0},
-	{NULL,  "VRAM",      pce_vram,      PSEUDO, P_VRAM,      0},
+	{NULL, "DEFCHR",     pce_defchr,    PSEUDO, P_DEFCHR,    0},
+	{NULL, "DEFPAL",     pce_defpal,    PSEUDO, P_DEFPAL,    0},
+	{NULL, "DEFSPR",     pce_defspr,    PSEUDO, P_DEFSPR,    0},
+	{NULL, "INCBAT",     pce_incbat,    PSEUDO, P_INCBAT,    NARGS_1_2_3_4_5_6},
+	{NULL, "INCSPR",     pce_incspr,    PSEUDO, P_INCSPR,    NARGS_0_2_4},
+	{NULL, "INCPAL",     pce_incpal,    PSEUDO, P_INCPAL,    NARGS_0_1_2},
+	{NULL, "INCTILE",    pce_inctile,   PSEUDO, P_INCTILE,   NARGS_0_2_4},
+	{NULL, "INCMAP",     pce_incmap,    PSEUDO, P_INCMAP,    NARGS_1_3_5},
+	{NULL, "INCCHRPAL",  pce_incchrpal, PSEUDO, P_INCCHRPAL, NARGS_0_2_4},
+	{NULL, "INCSPRPAL",  pce_incsprpal, PSEUDO, P_INCSPRPAL, NARGS_0_2_4},
+	{NULL, "INCTILEPAL", pce_inctilepal,PSEUDO, P_INCTILEPAL,NARGS_0_2_4},
+	{NULL, "MML",        pce_mml,       PSEUDO, P_MML,       0},
+	{NULL, "PAL",        pce_pal,       PSEUDO, P_PAL,       0},
+	{NULL, "VRAM",       pce_vram,      PSEUDO, P_VRAM,      0},
 
 	{NULL, ".DEFCHR",    pce_defchr,    PSEUDO, P_DEFCHR,    0},
 	{NULL, ".DEFPAL",    pce_defpal,    PSEUDO, P_DEFPAL,    0},
 	{NULL, ".DEFSPR",    pce_defspr,    PSEUDO, P_DEFSPR,    0},
-	{NULL, ".INCBAT",    pce_incbat,    PSEUDO, P_INCBAT,    0xD5},
-	{NULL, ".INCSPR",    pce_incspr,    PSEUDO, P_INCSPR,    0xEA},
-	{NULL, ".INCPAL",    pce_incpal,    PSEUDO, P_INCPAL,    0xF8},
-	{NULL, ".INCTILE",   pce_inctile,   PSEUDO, P_INCTILE,   0xEA},
-	{NULL, ".INCMAP",    pce_incmap,    PSEUDO, P_INCMAP,    0xD5},
-	{NULL, ".INCCHRPAL", pce_incchrpal, PSEUDO, P_INCCHRPAL, 0xEA},
-	{NULL, ".INCSPRPAL", pce_incsprpal, PSEUDO, P_INCSPRPAL, 0xEA},
-	{NULL, ".INCTILEPAL",pce_inctilepal,PSEUDO, P_INCTILEPAL,0xEA},
+	{NULL, ".INCBAT",    pce_incbat,    PSEUDO, P_INCBAT,    NARGS_1_2_3_4_5_6},
+	{NULL, ".INCSPR",    pce_incspr,    PSEUDO, P_INCSPR,    NARGS_0_2_4},
+	{NULL, ".INCPAL",    pce_incpal,    PSEUDO, P_INCPAL,    NARGS_0_1_2},
+	{NULL, ".INCTILE",   pce_inctile,   PSEUDO, P_INCTILE,   NARGS_0_2_4},
+	{NULL, ".INCMAP",    pce_incmap,    PSEUDO, P_INCMAP,    NARGS_1_3_5},
+	{NULL, ".INCCHRPAL", pce_incchrpal, PSEUDO, P_INCCHRPAL, NARGS_0_2_4},
+	{NULL, ".INCSPRPAL", pce_incsprpal, PSEUDO, P_INCSPRPAL, NARGS_0_2_4},
+	{NULL, ".INCTILEPAL",pce_inctilepal,PSEUDO, P_INCTILEPAL,NARGS_0_2_4},
 	{NULL, ".MML",       pce_mml,       PSEUDO, P_MML,       0},
 	{NULL, ".PAL",       pce_pal,       PSEUDO, P_PAL,       0},
 	{NULL, ".VRAM",      pce_vram,      PSEUDO, P_VRAM,      0},


### PR DESCRIPTION
…by adding

an "_OPTIMIZE" flag to the end of the parameters.

Add the ability to HuCC to remove repeated characters in a "#incbat" by adding a reference character set label name to the end of the parameters.

Implement the corresponding PCEAS changes to ".incchr" and ".incbat".

Add PCEAS's ".incmap" pseudo-op to HuCC as "#incmap()".