### PR TITLE
added load_vram_bank parameterized upload

### DIFF
--- a/include/hucc/hucc-baselib.asm
+++ b/include/hucc/hucc-baselib.asm
@@ -715,7 +715,8 @@ _set_sprpal.3	.macro
 ;
 ; void __fastcall __macro load_vram( unsigned int vram<_di>, unsigned char __far *data<_bp_bank:_bp>, unsigned int num_words<_ax> );
 ; void __fastcall __macro sgx_load_vram( unsigned int vram<_di>, unsigned char __far *data<_bp_bank:_bp>, unsigned int num_words<_ax> );
-;
+;; void __fastcall __macro load_vram_bank(unsigned int vram<_di>, unsigned int data<__bp>, unsigned char bank<_bp_bank>, unsigned int num_words<__cx>);
+
 ; void __fastcall __macro far_load_vram( unsigned int vram<_di>, unsigned int num_words<_ax> );
 ; void __fastcall __macro sgx_far_load_vram( unsigned int vram<_di>, unsigned int num_words<_ax> );
 ;
@@ -742,6 +743,10 @@ _set_sprpal.3	.macro
 		call	load_vram_x
 		.endm
 
+		.macro	_load_vram_bank.4
+		clx				; Offset to PCE VDC. with bank passed in. to enable dynamic upload from indirect data 
+		call	load_vram_x
+		.endm
 
 
 ; ***************************************************************************

--- a/include/hucc/hucc-gfx.h
+++ b/include/hucc/hucc-gfx.h
@@ -76,6 +76,7 @@ extern void __fastcall __macro sgx_put_vram( unsigned int address<_di>, unsigned
 extern void __fastcall load_palette( unsigned char palette<_al>, unsigned char __far *data<_bp_bank:_bp>, unsigned char num_palettes<_ah> );
 
 extern void __fastcall __macro load_vram( unsigned int vram<_di>, unsigned char __far *data<_bp_bank:_bp>, unsigned int num_words<_ax> );
+extern void __fastcall __macro load_vram_bank(unsigned int vram<_di>, unsigned int data<__bp>, unsigned char bank<_bp_bank>, unsigned int num_words<__cx>);
 extern void __fastcall __macro sgx_load_vram( unsigned int vram<_di>, unsigned char __far *data<_bp_bank:_bp>, unsigned int num_words<_ax> );
 
 extern void __fastcall load_bat( unsigned int vram<_di>, unsigned char __far *data<_bp_bank:_bp>, unsigned char tiles_w<_al>, unsigned char tiles_h<_ah> );


### PR DESCRIPTION
added load_vram_bank to enable more code control of source data. 

e.g. using multiple sprite source data sets and dynamic upload based on needs.