### PR TITLE
Change HuCC to generate local labels inside C functions.

### DIFF
--- a/include/hucc/hucc-codegen.asm
+++ b/include/hucc/hucc-codegen.asm
@@ -125,43 +125,26 @@ __short		.macro
 ; this is used for __far parameters to a __fastcall
 
 __farptr	.macro
-	.if	((\1) < $6000)
-		lda.l	#\1
-		sta.l	\3
-		lda.h	#\1
-		sta.h	\3
-		stz	\2
-	.else
 		lda.l	#$6000 + ($1FFF & (\1))
 		sta.l	\3
 		lda.h	#$6000 + ($1FFF & (\1))
 		sta.h	\3
 		lda	#bank(\1)
 		sta	\2
-	.endif
 		.endm
 
 ; **************
 ; adds 16-bit unsigned offset in Y:A to data address in \1, then \2=bank, \3=addr
 
 __farptr_i	.macro
-	.if	((\1) < $6000)
-		clc
-		adc.l	#\1
-		sta.l	\3
-		tya
-		adc.h	#\1
-		sta.h	\3
-		stz	\2
-	.else
 		clc
 		adc.l	#(\1) & $1FFF
 		sta.l	\3
 		tya
 		adc.h	#(\1) & $1FFF
 		tay
-		and	#$1F
-		ora	#$60
+		and.h	#$1FFF
+		ora.h	#$6000
 		sta.h	\3
 		tya
 		ror	a
@@ -172,7 +155,6 @@ __farptr_i	.macro
 		clc
 		adc	#bank(\1)
 		sta	\2
-	.endif
 		.endm
 
 ; **************

--- a/include/hucc/hucc-gfx.asm
+++ b/include/hucc/hucc-gfx.asm
@@ -825,6 +825,7 @@ _sgx_set_font_pal.1:
 		db	$F0			; Turn "clx" into a "beq".
 	.endif
 
+_set_font_pal:					; For compatibility with HuC.
 _set_font_pal.1:
 		clx				; Offset to PCE VDC.
 		asl	a

--- a/src/hucc/io.c
+++ b/src/hucc/io.c
@@ -361,14 +361,6 @@ void gnlabel (int nlab)
 }
 
 /*
- * Output internal generated label prefix
- */
-void olprfix (void)
-{
-	outstr("LL");
-}
-
-/*
  * Output a label definition terminator
  */
 void col (void)
@@ -485,7 +477,7 @@ void outconst (int label)
  */
 void outlabel (int label)
 {
-	olprfix();
+	outstr(".LL");
 	outdec(label);
 }
 

--- a/src/hucc/io.h
+++ b/src/hucc/io.h
@@ -36,7 +36,6 @@ int ch (void);
 
 void pl (char *str);
 void gnlabel (int nlab);
-void olprfix (void);
 void col (void);
 void comment (void);
 void prefix (void);

--- a/src/hucc/stmt.c
+++ b/src/hucc/stmt.c
@@ -549,7 +549,7 @@ void dolabel (char *name)
 			   We have to create a stack pointer offset EQU
 			   that describes the stack pointer difference from
 			   the goto to here. */
-			sprintf(name, "LL%d_stkp", clabels[i].label);
+			sprintf(name, ".LL%d_stkp", clabels[i].label);
 			/* XXX: memleak */
 			out_ins_ex(I_DEF, T_LITERAL, (intptr_t)strdup(name),
 				   T_VALUE, stkp - clabels[i].stkp);
@@ -603,7 +603,7 @@ void dogoto (void)
 	   to the label's relative SP at the time of definition. */
 	clabels[i].stkp = stkp;
 	clabels[i].label = getlabel();
-	sprintf(sname, "LL%d_stkp", clabels[i].label);
+	sprintf(sname, ".LL%d_stkp", clabels[i].label);
 	/* XXX: memleak */
 	out_ins(I_MODSP, T_LITERAL, (intptr_t)strdup(sname));
 	jump(clabels[i].label);

--- a/src/hucc/sym.c
+++ b/src/hucc/sym.c
@@ -250,19 +250,9 @@ int declglb (char typ, char stor, TAG_SYMBOL *mtag, int otag, int is_struct)
 				   can't think of a better place right now. */
 				if (id == POINTER && (typ_now == CCHAR || typ_now == CUCHAR || typ_now == CVOID))
 					k *= INTSIZE;
-				if (k || ((stor & STORAGE) == EXTERN))
-					id = ARRAY;
-				else {
-					if ((stor & STORAGE) == CONST) {
-						error("empty const array");
-						id = ARRAY;
-					}
-					else if (id == POINTER)
-						id = ARRAY;
-					else {
-						id = POINTER;
-						ptr_order++;
-					}
+				id = ARRAY;
+				if ((k == 0) && ((stor & STORAGE) == CONST)) {
+					error("empty const array");
 				}
 			}
 			else {
@@ -380,19 +370,11 @@ void declloc (char typ, char stclass, int otag)
 				multidef(sname);
 			if (match("[")) {
 				elements = k = needsub();
-				if (k) {
-					if (typ == CINT || typ == CUINT || j == POINTER)
-						k = k * INTSIZE;
-					else if (typ == CSTRUCT)
-						k *= tag_table[otag].size;
-					j = ARRAY;
-				}
-				else {
-					j = POINTER;
-					ptr_order++;
-					k = INTSIZE;
-					elements = 1;
-				}
+				if (typ == CINT || typ == CUINT || j == POINTER)
+					k = k * INTSIZE;
+				else if (typ == CSTRUCT)
+					k *= tag_table[otag].size;
+				j = ARRAY;
 			}
 			else {
 				elements = 1;

--- a/src/mkit/as/assemble.c
+++ b/src/mkit/as/assemble.c
@@ -227,6 +227,10 @@ assemble(int do_label)
 				if (!colsym(&i, 1))
 					return;
 			}
+			if ((hucc_mode) && (proc_ptr) && (prlnbuf[i] == ':') && (c != '.') && (c != '@') && (c != '!')) {
+				error("You cannot create a global location label inside a C function!");
+				return;
+			}
 			if (prlnbuf[i] == ':')
 				i++;
 			if ((lablptr = stlook(SYM_DEF)) == NULL)

--- a/src/mkit/as/command.c
+++ b/src/mkit/as/command.c
@@ -2634,10 +2634,10 @@ do_alias(int *ip)
 	}
 
 	/* check symbol */
-	if (symbol[1] == '.' || symbol[1] == '@') {
-		error(".ALIAS name cannot be a local label!");
-		return;
-	}
+//	if (symbol[1] == '.' || symbol[1] == '@') {
+//		error(".ALIAS name cannot be a local label!");
+//		return;
+//	}
 	if (symbol[1] == '!') {
 		error(".ALIAS name cannot be a multi-label!");
 		return;
@@ -2687,10 +2687,10 @@ do_alias(int *ip)
 		return;
 
 	/* check symbol */
-	if (symbol[1] == '.' || symbol[1] == '@') {
-		fatal_error("Cannot create a .ALIAS to a local label!");
-		return;
-	}
+//	if (symbol[1] == '.' || symbol[1] == '@') {
+//		fatal_error("Cannot create a .ALIAS to a local label!");
+//		return;
+//	}
 	if (symbol[1] == '!') {
 		fatal_error("Cannot create a .ALIAS to a multi-label!");
 		return;


### PR DESCRIPTION
This means that developers cannot create global labels inside `#asm` sections with C functions anymore, and doing so is now flagged as an error!

This change is badly needed so that HuCC can support separate-compilation for C files in the future.